### PR TITLE
feat: 添加SMTP截图支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ pyrightconfig.json
 /screenshots
 /3rdparty
 /temp
+
+# notify for smtp
+smtp_temp.bin

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -201,10 +201,10 @@ notify_smtp_enable: false
 notify_smtp_host: ''
 notify_smtp_user: ''
 notify_smtp_password: ''
-notify_smtp_From: '' # 可选参数
-notify_smtp_To: '' # 可选参数
-notify_smtp_port: '' # 可选参数
-notify_smtp_ssl: '' # 可选参数
+notify_smtp_From: '' # 可选参数，默认user
+notify_smtp_To: '' # 可选参数，默认user
+notify_smtp_port: '' # 可选参数，默认465
+notify_smtp_ssl: '' # 可选参数，默认为True，可设置为False关闭
 
 # 钉钉通知
 notify_dingtalk_enable: false


### PR DESCRIPTION
为 SMTP 邮箱通知加入和Telegram 与 go-cqhttp 一样的发送截图操作的支持，邮件效果如图
![1499e7f28ffbfffed9d2fc53e6d17a9f_720](https://github.com/moesnow/March7thAssistant/assets/69845097/d3057516-9413-4f1f-92c7-bf6de0392ccd)
