### PR TITLE
修复 README 标题线遮盖 logo 的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div>  
-<p>
-    <img src="./assets/screenshot/March7th.png" align="right">
-</p>
 
 <h1>
+<img src="./assets/screenshot/March7th.png" align="right">
 March7thAssistant · 三月七小助手
 </h1>
 


### PR DESCRIPTION
before:

![I3UZZK9M@K4%U Q}JA() 6P](https://github.com/moesnow/March7thAssistant/assets/15783049/d90d8829-e2ec-40d1-af54-0f1381036c1f)

after:

![image](https://github.com/moesnow/March7thAssistant/assets/15783049/4c5eeb99-9652-442b-af39-00834630e1b7)
