### PR TITLE
Starttls for smtp

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -265,6 +265,7 @@ notify_smtp_From: "" # 发件人邮箱，默认为 smtp_user。
 notify_smtp_To: "" # 收件人邮箱，默认为 smtp_user。
 notify_smtp_port: "" # SMTP 服务器端口，默认为 465。
 notify_smtp_ssl: "" # 是否使用 SSL 连接 SMTP 服务器。默认为 True，可设置为 False 关闭。
+notify_smtp_starttls: "" # 是否使用 SSL 连接 SMTP 服务器。默认为 False，可设置为 True 关闭。
 
 # 钉钉通知配置
 notify_dingtalk_enable: false # 是否启用钉钉通知。true 开启，false 关闭。

--- a/module/notification/smtp.py
+++ b/module/notification/smtp.py
@@ -4,6 +4,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
 from .notifier import Notifier
+import ssl
 
 
 class SMTPNotifier(Notifier):
@@ -18,6 +19,7 @@ class SMTPNotifier(Notifier):
         To = self.params.get("To", user)
         port = self.params.get("port", 465)
         ssl = self.params.get("ssl", True)
+        starttls = self.params.get("starttls", False)
 
         msg = MIMEMultipart('related')
         body = f'<p>{content}<br>'
@@ -33,7 +35,10 @@ class SMTPNotifier(Notifier):
             msg.attach(img)
         msg.attach(MIMEText(body, "html", "utf-8"))
 
-        if ssl:
+        if starttls:
+            smtp = smtplib.SMTP(host, port)
+            smtp.starttls()
+        elif ssl:
             smtp = smtplib.SMTP_SSL(host, port)
         else:
             smtp = smtplib.SMTP(host, port)


### PR DESCRIPTION
解决无法使用outlook邮箱发送通知的问题

```
2024-04-09 15:50:36,007 | INFO | winotify 通知发送完成
2024-04-09 15:50:36,180 | ERROR | smtp 通知发送失败: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1007)
按回车键关闭窗口. . .
```

因为没有支持STARTTLS

解决方案，增加配置，支持STARTTLS