### PR TITLE
Query system pac settings from registry for telegram bot

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -233,7 +233,7 @@ notify_telegram_enable: false # 是否启用 Telegram 通知。true 开启，fal
 notify_telegram_token: "" # Telegram bot 的 token。
 notify_telegram_userid: "" # 接收通知的用户或群组 ID。
 notify_telegram_api_url: "" # 可选参数，Telegram API 的自定义URL，默认为空。
-notify_telegram_proxies: "" # 可选参数，请求 Telegram API 是否使用代理。默认为空(不使用)。例如："socks5://127.0.0.1:1080/" 。
+notify_telegram_proxies: "" # 可选参数，请求 Telegram API 是否使用代理。默认为空(使用系统PAC或不使用)。例如："127.0.0.1:10808", "socks5://127.0.0.1:1080/" 。
 
 # Server酱·Turbo版通知配置
 # 微信推送，适合小白，免费版每天限制五条

--- a/module/notification/telegram.py
+++ b/module/notification/telegram.py
@@ -1,5 +1,71 @@
 import requests
 from .notifier import Notifier
+import pypac
+import winreg
+
+PAC_REG_KEY = "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
+
+
+def query_system_pac_settings() -> str | None:
+    r"""
+    Query system pac settings from registry.
+    :return: pac url or None
+    """
+    try:
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, PAC_REG_KEY)
+        value, _ = winreg.QueryValueEx(key, "AutoConfigURL")
+        winreg.CloseKey(key)
+        if value:
+            return value
+        else:
+            return None
+    except FileNotFoundError:
+        return None
+
+
+def macth_pac_settings(url: str, pac_url: str):
+    r"""
+    Match pac settings from pac url.
+    :param url: url
+    :param pac_url: pac url
+    :return: proxy or None
+    """
+    pac = pypac.get_pac(url=pac_url)
+    pac_result = pac.find_proxy_for_url(url=url, host="0.0.0.0")
+    print(type(pac_result), pac_result)
+    if isinstance(pac_result, str):
+        pac_result = pac_result.split(";")
+        pac_result = map(lambda x: x.strip(), pac_result)
+        pac_result = filter(lambda x: x, pac_result)
+        pac_result = list(pac_result)
+        if len(pac_result) > 0:
+            pac_result = pac_result[0]
+            if pac_result == "DIRECT":
+                return None
+            if pac_result.startswith("PROXY"):
+                pac_result = pac_result.split(" ")
+                if len(pac_result) == 2:
+                    pac_result = pac_result[1]
+                    pac_result = pac_result.split(":")
+                    if len(pac_result) == 2:
+                        return f"{pac_result[0]}:{pac_result[1]}"
+
+
+def match_proxy(proxies_param: str | None, api_url: str) -> dict | None:
+    r"""
+    Match proxy from system pac settings or proxies param
+    :param proxies_param: proxies_param
+    :param url: url
+    :return: proxies
+    """
+    if proxies_param is not None:
+        return {"http": proxies_param, "https": proxies_param}
+    pac_url = query_system_pac_settings()
+    if pac_url is not None:
+        proxy = macth_pac_settings(api_url, pac_url)
+        if proxy is not None:
+            return {"http": proxy, "https": proxy}
+    return None
 
 
 class TelegramNotifier(Notifier):
@@ -10,10 +76,8 @@ class TelegramNotifier(Notifier):
         token = self.params["token"]
         chat_id = self.params["userid"]
         api_url = self.params.get("api_url", "api.telegram.org")
-        proxies = self.params["proxies"]
-        proxies = None if proxies is None else {
-            "https": proxies, "http": proxies,
-        }
+        proxies = match_proxy(self.params.get(
+            "proxies", None), f"https://{api_url}/")
 
         # 构建消息文本
         message = title if not content else f'{title}\n{content}' if title else content

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pylnk3
 pyperclip
 qrcode
 pysocks
+pypac


### PR DESCRIPTION

`self.params["proxies"]` 改成了 `self.params.get("proxies", None)` 不然不填的时候会报错

不设置proxies时候自动读取系统pac进行访问telegramApi。
