### PR TITLE
ssl_unverified for smtp

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -276,6 +276,7 @@ notify_smtp_To: "" # 收件人邮箱，默认为 smtp_user。
 notify_smtp_port: "" # SMTP 服务器端口，默认为 465。
 notify_smtp_ssl: "" # 是否使用 SSL 连接 SMTP 服务器。默认为 True，可设置为 False 关闭。
 notify_smtp_starttls: "" # 是否使用 SSL 连接 SMTP 服务器。默认为 False，可设置为 True 关闭。
+notify_smtp_ssl_unverified: "" # 是否使用不经验证的 SSL 连接。默认为 False，可设置为 True 关闭。除非您使用自签名邮箱,否则不推荐启用。
 
 # 钉钉通知配置
 notify_dingtalk_enable: false # 是否启用钉钉通知。true 开启，false 关闭。

--- a/module/notification/smtp.py
+++ b/module/notification/smtp.py
@@ -20,6 +20,8 @@ class SMTPNotifier(Notifier):
         port = self.params.get("port", 465)
         ssl = self.params.get("ssl", True)
         starttls = self.params.get("starttls", False)
+        ssl_unverified = self.params.get("ssl_unverified", False)
+
 
         msg = MIMEMultipart('related')
         body = f'<p>{content}<br>'
@@ -37,11 +39,16 @@ class SMTPNotifier(Notifier):
 
         if starttls:
             smtp = smtplib.SMTP(host, port)
-            smtp.starttls()
+            smtp.starttls(context=sslcontext(ssl_unverified))
         elif ssl:
-            smtp = smtplib.SMTP_SSL(host, port)
+            smtp = smtplib.SMTP_SSL(host, port, context=sslcontext(ssl_unverified))
         else:
             smtp = smtplib.SMTP(host, port)
         smtp.login(user, password)
         smtp.sendmail(From, To, msg.as_string())
         smtp.quit()
+
+def sslcontext(ssl_unverified):
+    if ssl_unverified:
+        return ssl._create_unverified_context()
+    return None


### PR DESCRIPTION
SMTP的跳过SSL证书域名验证, 以支持自签名证书和自建邮箱服务器