### PR TITLE
feat: 新增serverchan3的推送逻辑

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -253,6 +253,12 @@ notify_serverchanturbo_sctkey: "" # Server酱·Turbo 版的 SendKey。
 notify_serverchanturbo_channel: "" # 可选参数
 notify_serverchanturbo_openid: "" # 可选参数
 
+# Server酱·3版通知配置
+# Server酱的APP推送
+# https://sc3.ft07.com/
+notify_serverchan3_enable: false # 是否启用 Server酱·3 版通知。true 开启，false 关闭。
+notify_serverchan3_sendkey: "" # Server酱·3 版的 SendKey。
+
 # Bark 通知配置
 # 推荐 iOS 用户使用，直接在 App Store 下载安装
 notify_bark_enable: false # 是否启用 Bark 通知。true 开启，false 关闭。

--- a/module/notification/__init__.py
+++ b/module/notification/__init__.py
@@ -3,6 +3,7 @@ from module.logger import log
 from module.notification.notification import Notification
 # 导入所有通知器类型
 from module.notification.onepush import OnepushNotifier
+from module.notification.serverchan3 import ServerChanNotifier
 from module.notification.winotify import WinotifyNotifier
 from module.notification.telegram import TelegramNotifier
 from module.notification.onebot import OnebotNotifier
@@ -23,7 +24,8 @@ class NotifierFactory:
         "gocqhttp": GocqhttpNotifier,
         "wechatworkapp": WeChatworkappNotifier,
         "custom": CustomNotifier,
-        "lark": LarkNotifier
+        "lark": LarkNotifier,
+        "serverchan3": ServerChanNotifier,
     }
 
     @staticmethod

--- a/module/notification/serverchan3.py
+++ b/module/notification/serverchan3.py
@@ -1,0 +1,59 @@
+import requests
+import re
+import io
+from typing import Dict, Any, Optional
+from utils.logger.logger import Logger
+from .notifier import Notifier
+
+
+class ServerChanNotifier(Notifier):
+    def __init__(self, params: Dict[str, Any], logger: Logger):
+        """
+        初始化 ServerChan 通知器。
+
+        :param params: 初始化通知发送者所需的参数字典。
+        :param logger: 用于记录日志的 Logger 实例。
+        """
+        super().__init__(params, logger)
+        self.sendkey = params.get('sendkey')
+
+        if not self.sendkey:
+            raise ValueError("Sendkey is required for ServerChanNotifier")
+
+    def send(self, title: str, content: str, image_io: Optional[io.BytesIO] = None):
+        """
+        使用 ServerChan 发送通知。
+        兼容 ServerChan·Turbo 和 ServerChan·3。
+
+        :param title: 通知标题。
+        :param content: 通知内容。
+        :param image_io: 可选，发送的图片，为 io.BytesIO 对象。（ServerChan 暂时不支持直接发送图片。但支持 markdown 格式的图片链接）
+        """
+        # 根据 sendkey 决定 URL（兼容server酱Turbo）
+        if self.sendkey.startswith('sctp'):
+            match = re.match(r'sctp(\d+)t', self.sendkey)
+            if match:
+                num = match.group(1)
+                url = f'https://{num}.push.ft07.com/send/{self.sendkey}.send'
+            else:
+                raise ValueError('Invalid sendkey format for Server酱3')
+        else:
+            url = f'https://sctapi.ftqq.com/{self.sendkey}.send'
+
+        params = {
+            'title': title,
+            'desp': content,
+        }
+        headers = {
+            'Content-Type': 'application/json;charset=utf-8'
+        }
+
+        # 发送请求
+        try:
+            response = requests.post(url, json=params, headers=headers)
+            response.raise_for_status()  # 检查请求是否成功
+            result = response.json()
+            if result.get("code") != 0:
+                self.logger.error(f"ServerChan3 通知发送失败: {result.get('message')}")
+        except requests.RequestException as e:
+            self.logger.error(f"ServerChan3 通知发送失败: {e}")


### PR DESCRIPTION
Server酱3官网：https://sc3.ft07.com/。
虽然有Python的SDK，但是目前仅仅支持发送markdown格式的图片，待之后更新支持发送图片后再使用SDK进行发送。 
代码兼容了Server酱Turbo的sendkey，可以直接发送Server酱Turbo的消息。
目前官方依然保留了通过Server酱Turbo的接口直接发送Server酱3的消息，但是会有广告。
目前Server酱3是免费的，没有条数限制，因而添加了server酱3的推送逻辑。

另外，我想问一下原本的Server酱Turbo的发送逻辑是怎么实现的，我在代码中没有找到....