### PR TITLE
Enable screenshot on multiple monitors

### DIFF
--- a/module/automation/screenshot.py
+++ b/module/automation/screenshot.py
@@ -1,6 +1,6 @@
-from PIL import Image
 import pyautogui
 import win32gui
+from PIL import Image
 
 
 class Screenshot:
@@ -43,7 +43,7 @@ class Screenshot:
                 int(top + height * crop[1]),
                 int(width * crop[2]),
                 int(height * crop[3])
-            ))
+            ), allScreens=True)
 
             real_width, _ = Screenshot.get_window_real_resolution(window)
             if real_width > 1920:


### PR DESCRIPTION
发现的问题: 
当星铁程序窗口位于多显示器副屏时, 得到的截图结果为全黑图片.

解决方案: 
在执行 `pyautogui.screenshot()` 方法截图时, 使用参数 `allScreens=True`.

效果:
无论星铁程序窗口位于多显示器主屏, 副屏, 亦或者是跨屏幕显示时, 都能得到正确的截图.