### PR TITLE
修复了多显示器上无法正确获得截屏区域的问题

### DIFF
--- a/module/automation/screenshot.py
+++ b/module/automation/screenshot.py
@@ -1,6 +1,6 @@
 import pyautogui
 import win32gui
-from PIL import Image
+from desktopmagic.screengrab_win32 import getDisplayRects
 
 
 class Screenshot:
@@ -33,14 +33,23 @@ class Screenshot:
         return False
 
     @staticmethod
+    def get_main_screen_location():
+        rects = getDisplayRects()
+        min_x = min([rect[0] for rect in rects])
+        min_y = min([rect[1] for rect in rects])
+        return -min_x, -min_y
+    
+    @staticmethod
     def take_screenshot(title, crop=(0, 0, 1, 1)):
         window = Screenshot.get_window(title)
         if window:
             left, top, width, height = Screenshot.get_window_region(window)
 
+            offset_x, offset_y = Screenshot.get_main_screen_location()
+            
             screenshot = pyautogui.screenshot(region=(
-                int(left + width * crop[0]),
-                int(top + height * crop[1]),
+                int(left + width * crop[0] + offset_x),
+                int(top + height * crop[1] + offset_y),
                 int(width * crop[2]),
                 int(height * crop[3])
             ), allScreens=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ qrcode
 pysocks
 pypac
 requests_toolbelt
+desktopmagic


### PR DESCRIPTION
(目前仅在Windows 11上进行了测试)

在 "扩展" 模式下使用多显示器时, 获取窗口坐标的原点为主显示器左上角, 而截屏的坐标原点为所有显示器合并之后的图片左上角. 如果主屏不是最为左上角的屏幕时, 会造成这两个坐标原点不匹配. 这个pr主要是修复了这个问题, 但不保证能够完全修复 #383 .