### PR TITLE
增加一些账号管理的提示

### DIFF
--- a/app/sub_interfaces/accounts_interface.py
+++ b/app/sub_interfaces/accounts_interface.py
@@ -3,7 +3,7 @@ from typing import Union
 from qfluentwidgets import SettingCard, SettingCardGroup, ListWidget, FluentIconBase, CardWidget, FluentStyleSheet
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QPushButton, QListWidgetItem, QVBoxLayout, QMessageBox, QInputDialog, QLineEdit
+from PyQt5.QtWidgets import QPushButton, QListWidgetItem, QVBoxLayout, QMessageBox, QInputDialog, QLineEdit, QLabel
 from PyQt5.QtWidgets import QHBoxLayout, QGridLayout, QFrame
 from qfluentwidgets import FluentIcon as FIF
 from PyQt5.QtGui import QPalette
@@ -27,6 +27,11 @@ class AccountsCard(QFrame):
         #
         self.buttons = QVBoxLayout()
         self.buttons.setContentsMargins(10, 3, 10, 3)
+        self.tipsText = QLabel("重要: 请完全进入游戏(看到角色)后再进行导出，否则会读取前一个账号的UID，导致文件和账号不对应")
+        self.tipsText.setWordWrap(True)
+        self.tipsText.setStyleSheet('color: red')
+        self.buttons.addWidget(self.tipsText)
+        self.tipsText.setFixedHeight(50)
         self.addAccountButton = QPushButton("导出当前游戏账户", self)
         self.importAccountButton = QPushButton("导入选中的账户", self)
         self.deleteAccountButton = QPushButton("删除账户", self)


### PR DESCRIPTION

我使用【账号导出】功能，登录第二个账号的之后，反复导出发现账号注册表文件并没有变多。

我反复对照注册表。是因为登录后，只停留在火车头页面，注册表中`App_LastUserID_h2841727341`这个值保存的还是上一个账号的UID（直到我进入游戏主界面这个值才更新）

上述情况点击导出时，会造成比较严重的后果，获取到的旧的账号(A)的UID，但是身份信息是新的账号(B)的信息，并且保存到了A的文件中。

以后再导入A账号，结果登录的是B。

我不知道怎么优化这个虫子，暂时加了TIPS，Ownner可以根据喜好合并或者关闭
