### PR TITLE
doc: 修改后台运行文档，添加win11的说明

### DIFF
--- a/assets/docs/Background.md
+++ b/assets/docs/Background.md
@@ -13,3 +13,24 @@
    * 备用链接
      * [百度网盘](https://pan.baidu.com/s/13aoll4n1gmKlPT9WwNYeEw?pwd=jbha) 提取码：jbha
      * [GitHub镜像](https://github.kotori.top/https://github.com/CHNZYX/asu_version_latest/releases/download/RDP/LocalRemoteDesktop1.191_by_lin.zip)
+
+
+
+## 对于 Windows 11 用户
+
+在 [详细教程 by_Rin](https://www.bilibili.com/read/cv24286313/) 中提到的 `SuperRDP` 软件可能已无法使用，建议改用 [TermsrvPatcher](https://github.com/fabianosrc/TermsrvPatcher)。如果你在国内使用，可以通过备用链接下载：[蓝奏云](https://wwsj.lanzout.com/i4V8u2np8dna)。
+
+**注意：** 此方法仅实现了[详细教程 by_Rin](https://www.bilibili.com/read/cv24286313/)中`4. 多用户同时登陆补丁`的功能，其余步骤请继续按照原教程进行。
+
+**使用方法：**
+
+1. 使用 `git clone` 克隆仓库，或直接下载压缩包。
+2. 下载完成后，解压压缩包，找到 `TermsrvPatcher.ps1` 文件，右键点击选择“运行”，脚本将自动完成所有操作。
+
+此外，如果你希望手动修改文件，可以参考博客文章：[修改文件方法](https://www.wyr.me/post/701)。不过需要注意的是，该博客中的部分操作在 Windows 11 上可能不适用，具体如下：
+
+- **在 Windows 11 中需搜索的字符串（正则）：**
+   `39 81 3C 06 00 00 0F (?:[0-9A-F]{2} ){4}00`（实际操作中，仅需搜索`39 81 3C 06 00 00 0F`即可，剩下的两个16进制数符合正则表达式再进行修改）
+- **替换为的字符串：**
+   `8B 81 38 06 00 00 39 81 3C 06 00 00 75`
+


### PR DESCRIPTION
Win11 24h2 上，原来的 SuperRDP 因为两年没更新，服务器也停了，导致没法更新。虽然isuess中有解决办法和修补好的，但是各种改权限组有点麻烦。
来GitHub找了一圈发现[TermsrvPatcher](https://github.com/fabianosrc/TermsrvPatcher)，这个可以直接用，兼容Win 11 24H2。