### PR TITLE
Fix: 修改储存的时间格式为24小时制，解决 #511

### DIFF
--- a/app/card/timepickersettingcard1.py
+++ b/app/card/timepickersettingcard1.py
@@ -23,4 +23,4 @@ class TimePickerSettingCard1(SettingCard):
         self.timePicker.timeChanged.connect(self._onTimeChanged)
 
     def _onTimeChanged(self, time: QTime):
-        cfg.set_value(self.configname, time.toString(Qt.DefaultLocaleShortDate))
+        cfg.set_value(self.configname, time.toString("HH:mm"))  # 保存24小时制的时间到配置文件


### PR DESCRIPTION
目前使用的是 time.toString(Qt.DefaultLocaleShortDate)，它会根据本地系统区域设置返回时间，可能会是 12 小时制。然后这个组件目前只能读取24小时制的config数据