### PR TITLE
修复飞书推送

### DIFF
--- a/module/notification/lark.py
+++ b/module/notification/lark.py
@@ -44,7 +44,7 @@ class LarkNotifier(Notifier):
         webhook = self.params["webhook"]
 
         imageenable = self.params["imageenable"]
-        # 如果支持发送图片，并且图片功能已启用
+        # 图片功能已启用，且需要发送图片
         if imageenable and image_io is not None:
             # 获取飞书的认证令牌
             auth_endpoint = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
@@ -98,8 +98,8 @@ class LarkNotifier(Notifier):
                 }
             }
 
-        # 如果不支持发送图片
-        if not imageenable:
+        # 不需要发送图片 或图片功能未启用
+        else:
             send_message = {
                 "msg_type": "post",
                 "content": {

--- a/module/notification/lark.py
+++ b/module/notification/lark.py
@@ -72,10 +72,10 @@ class LarkNotifier(Notifier):
             image_key = image_response.json()["data"]["image_key"]
 
             # 构造发送的消息内容
-            if self.params["keyword"] is not None:
-                content = content + '\n' + self.params["keyword"]
-            if self.params["keyword"] == '' or self.params["keyword"] is None:
-                content = content
+            if self.params.get("keyword", None) is not None:
+                if self.params["keyword"] != '':
+                    content = content + '\n' + self.params["keyword"]
+
             send_message = {
                 "msg_type": "post",
                 "content": {
@@ -115,7 +115,7 @@ class LarkNotifier(Notifier):
                 }
             }
         # 如果需要签名
-        if self.params["sign"] is not None:
+        if self.params.get("sign", None) is not None and self.params["sign"] != '':
             sign = self.params["sign"]
             timestamp = str(int(time.time()))
             send_message.update({


### PR DESCRIPTION
fix: lark notify

![image](https://github.com/user-attachments/assets/53e853f2-de4a-4e2a-a370-d0cd2d44efab)

如图，以及代码，所有的推送方式中 

当一个key对应的value为空字符串，`self.params["key"]` 的取值均会报错。改成`self.params.get("key", None)` .

即dict没有这个key，不能用[]取

不知道从哪个版本开始的就这样了，以前处理过类似的问题

#222 
