### PR TITLE
feat：将最大开拓力改为最大挑战次数，并在GUI中提供修改选项

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -96,6 +96,13 @@ class SettingInterface(ScrollArea):
             "instance_names",
             "./assets/config/instance_names.json"
         )
+        self.maxCalyxPerRoundPowerCard = RangeSettingCard1(
+            "max_calyx_per_round_num_of_attempts",
+            [1, 6],
+            FIF.HISTORY,
+            self.tr("每轮拟造花萼挑战次数"),
+            '',
+        )
         self.breakDownLevelFourRelicsetEnableCard = SwitchSettingCard1(
             FIF.FILTER,
             self.tr('自动分解四星遗器'),
@@ -759,6 +766,7 @@ class SettingInterface(ScrollArea):
         self.PowerGroup.addSettingCard(self.instanceTypeCard)
         # self.PowerGroup.addSettingCard(self.calyxGoldenPreferenceCard)
         self.PowerGroup.addSettingCard(self.instanceNameCard)
+        self.PowerGroup.addSettingCard(self.maxCalyxPerRoundPowerCard)
         self.PowerGroup.addSettingCard(self.breakDownLevelFourRelicsetEnableCard)
         self.PowerGroup.addSettingCard(self.instanceTeamEnableCard)
         # self.PowerGroup.addSettingCard(self.instanceTeamNumberCard)

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -96,7 +96,7 @@ class SettingInterface(ScrollArea):
             "instance_names",
             "./assets/config/instance_names.json"
         )
-        self.maxCalyxPerRoundPowerCard = RangeSettingCard1(
+        self.maxCalyxPerRoundNumOfAttempts = RangeSettingCard1(
             "max_calyx_per_round_num_of_attempts",
             [1, 6],
             FIF.HISTORY,
@@ -766,7 +766,7 @@ class SettingInterface(ScrollArea):
         self.PowerGroup.addSettingCard(self.instanceTypeCard)
         # self.PowerGroup.addSettingCard(self.calyxGoldenPreferenceCard)
         self.PowerGroup.addSettingCard(self.instanceNameCard)
-        self.PowerGroup.addSettingCard(self.maxCalyxPerRoundPowerCard)
+        self.PowerGroup.addSettingCard(self.maxCalyxPerRoundNumOfAttempts)
         self.PowerGroup.addSettingCard(self.breakDownLevelFourRelicsetEnableCard)
         self.PowerGroup.addSettingCard(self.instanceTeamEnableCard)
         # self.PowerGroup.addSettingCard(self.instanceTeamNumberCard)

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -40,7 +40,7 @@ instance_names:
   侵蚀隧洞: 睿治之径
   饰品提取: 永恒笑剧
   历战余响: 毁灭的开端 # 配置各副本类型的名称。
-max_calyx_per_round_power: 60 # 设置每轮拟造花萼的最大开拓力消耗。
+max_calyx_per_round_num_of_attempts: 6 # 设置每轮拟造花萼挑战次数。
 
 # 分解设置
 break_down_level_four_relicset: false # 完成侵蚀隧洞、饰品提取、历战余响和模拟宇宙后是否自动分解四星及以下遗器。true 开启，false 关闭。

--- a/tasks/activity/__init__.py
+++ b/tasks/activity/__init__.py
@@ -15,7 +15,7 @@ class ActivityManager:
         self.giftofodyssey = CheckInActivity("巡星之礼", cfg.activity_dailycheckin_enable)
         self.giftofradiance = CheckInActivity("巡光之礼", cfg.activity_dailycheckin_enable)
         self.festivegifts = CheckInActivity("庆典祝礼", cfg.activity_dailycheckin_enable)
-        self.gardenofplenty = GardenOfPlenty("花藏繁生", cfg.activity_gardenofplenty_enable, cfg.activity_gardenofplenty_instance_type, cfg.instance_names, cfg.max_calyx_per_round_power)
+        self.gardenofplenty = GardenOfPlenty("花藏繁生", cfg.activity_gardenofplenty_enable, cfg.activity_gardenofplenty_instance_type, cfg.instance_names, cfg.max_calyx_per_round_num_of_attempts)
         self.realmofthestrange = RealmOfTheStrange("异器盈界", cfg.activity_realmofthestrange_enable, cfg.instance_names)
         self.realmofthestrange3 = RealmOfTheStrange("异器盈界300%", cfg.activity_realmofthestrange_enable, cfg.instance_names)
         self.planarfissure = PlanarFissure("位面分裂", cfg.activity_planarfissure_enable, cfg.instance_names)

--- a/tasks/activity/gardenofplenty.py
+++ b/tasks/activity/gardenofplenty.py
@@ -4,19 +4,19 @@ from .doubleactivity import DoubleActivity
 
 
 class GardenOfPlenty(DoubleActivity):
-    def __init__(self, name, enabled, instance_type, instance_names, max_calyx_per_round_power):
+    def __init__(self, name, enabled, instance_type, instance_names, max_calyx_per_round_num_of_attempts):
         super().__init__(name, enabled)
         self.instance_type = instance_type
         self.instance_names = instance_names
-        self.max_calyx_per_round_power = max_calyx_per_round_power
+        self.max_calyx_per_round_num_of_attempts = max_calyx_per_round_num_of_attempts
 
     def _run_instances(self, reward_count):
         instance_type = self.instance_type
         instance_name = self.instance_names[instance_type]
-        max_calyx_per_round_power = self.max_calyx_per_round_power
+        max_calyx_per_round_num_of_attempts = self.max_calyx_per_round_num_of_attempts
         instance_power_min = 10
-        if (max_calyx_per_round_power % 10 == 0 and max_calyx_per_round_power >= 10 and max_calyx_per_round_power <= 60):
-            instance_power_max = max_calyx_per_round_power
+        if (max_calyx_per_round_num_of_attempts >= 1 and max_calyx_per_round_num_of_attempts <= 6):
+            instance_power_max = max_calyx_per_round_num_of_attempts * 10
         else:
             instance_power_max = 60
 

--- a/tasks/power/power.py
+++ b/tasks/power/power.py
@@ -14,7 +14,7 @@ class Power:
 
         instance_type = cfg.instance_type
         instance_name = cfg.instance_names[cfg.instance_type]
-        max_calyx_per_round_power = cfg.max_calyx_per_round_power
+        max_calyx_per_round_num_of_attempts = cfg.max_calyx_per_round_num_of_attempts
 
         if not Instance.validate_instance(instance_type, instance_name):
             return False
@@ -25,7 +25,7 @@ class Power:
             power = Power.get()
             Power.process_ornament(instance_type, instance_name, power)
         elif "拟造花萼" in instance_type:
-            Power.process_calyx(instance_type, instance_name, max_calyx_per_round_power)
+            Power.process_calyx(instance_type, instance_name, max_calyx_per_round_num_of_attempts)
         else:
             power = Power.get()
             Power.process_standard(instance_type, instance_name, power)
@@ -80,11 +80,11 @@ class Power:
             Instance.run(instance_type, instance_name, 40, immersifier_count + full_runs)
 
     @staticmethod
-    def process_calyx(instance_type, instance_name, max_calyx_per_round_power):
+    def process_calyx(instance_type, instance_name, max_calyx_per_round_num_of_attempts):
         # 处理拟造花萼的体力消耗
         instance_power_min = 10
-        if (max_calyx_per_round_power % 10 == 0 and max_calyx_per_round_power >= 10 and max_calyx_per_round_power <= 60):
-            instance_power_max = max_calyx_per_round_power
+        if (max_calyx_per_round_num_of_attempts >= 1 and max_calyx_per_round_num_of_attempts <= 6):
+            instance_power_max = max_calyx_per_round_num_of_attempts * 10
         else:
             instance_power_max = 60
         while True:


### PR DESCRIPTION
# 此 PR 完善了之前 PR #545 中未实现的功能

## 内容
> ### 每轮拟造花萼的最大开拓力消耗 -> 每轮拟造花萼的挑战次数
> - 在 assets/config/config.example.yaml 中将 **max_calyx_per_round_power** 改为**max_calyx_per_round_num_of_attempts** ，用于设置每轮拟造花萼的挑战次数，默认值为6次。
> - 在 tasks/activity/__init__.py 、tasks/activity/gardenofplenty.py 、tasks/power/power.py 中对函数接口等进行修改以适配 config 的变化。
> - 在 tasks/power/power.py 以及 tasks/activity/gardenofplenty.py 中修改了 instance_power_max 的获取逻辑，使用 max_calyx_per_round_num_of_attempts 计算得到。

> ### 为 “每轮拟造花萼挑战次数” 在GUI中提供修改选项
>- 修改了 app/setting_interface.py ，以实现在GUI中提供 **每轮拟造花萼挑战次数** (max_calyx_per_round_num_of_attempts) 的修改选项

## 附加信息
- 关联 issue ： issue #544 