### PR TITLE
feat：为设置页面的滑块增加按钮以便更精细的控制

### DIFF
--- a/app/card/rangesettingcard1.py
+++ b/app/card/rangesettingcard1.py
@@ -1,9 +1,9 @@
 from typing import Union
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal, QSize
 from PyQt5.QtGui import QColor, QIcon, QPainter
 from PyQt5.QtWidgets import (QFrame, QHBoxLayout, QLabel, QToolButton, QVBoxLayout, QPushButton)
-from qfluentwidgets import (SettingCard, FluentIconBase, SwitchButton, IndicatorPosition, Slider)
+from qfluentwidgets import (SettingCard, FluentIconBase, SwitchButton, IndicatorPosition, Slider, FluentIcon)
 
 from module.config import cfg
 
@@ -38,6 +38,16 @@ class RangeSettingCard1(SettingCard):
         self.valueLabel = QLabel(self)
         self.slider.setMinimumWidth(268)
 
+        self.minusButton = QToolButton()  # 新增减按钮
+        self.plusButton = QToolButton()   # 新增加按钮
+        self.minusButton.setIcon(FluentIcon.REMOVE.icon())  # 减号按钮图标
+        self.plusButton.setIcon(FluentIcon.ADD.icon())      # 加号按钮图标
+
+        self.minusButton.setFixedSize(28, 28)   # 设置按钮大小
+        self.plusButton.setFixedSize(28, 28)    # 设置按钮大小
+        self.minusButton.setIconSize(QSize(12, 12))  # 图标大小
+        self.plusButton.setIconSize(QSize(12, 12))   # 图标大小
+
         self.slider.setSingleStep(1)
         self.slider.setRange(Range[0], Range[1])
         self.slider.setValue(int(cfg.get_value(self.configname)))
@@ -45,13 +55,19 @@ class RangeSettingCard1(SettingCard):
 
         self.hBoxLayout.addStretch(1)
         self.hBoxLayout.addWidget(self.valueLabel, 0, Qt.AlignRight)
-        self.hBoxLayout.addSpacing(6)
+        self.hBoxLayout.addSpacing(10)
+        self.hBoxLayout.addWidget(self.minusButton, 0, Qt.AlignRight)  # 加入减号按钮
+        self.hBoxLayout.addSpacing(4)  # 在减号按钮和滑块之间增加4像素间隔
         self.hBoxLayout.addWidget(self.slider, 0, Qt.AlignRight)
+        self.hBoxLayout.addSpacing(4)  # 在滑块和加号按钮之间增加4像素间隔
+        self.hBoxLayout.addWidget(self.plusButton, 0, Qt.AlignRight)   # 加入加号按钮
         self.hBoxLayout.addSpacing(16)
 
         self.valueLabel.setObjectName('valueLabel')
         # configname.valueChanged.connect(self.setValue)
         self.slider.valueChanged.connect(self.__onValueChanged)
+        self.minusButton.clicked.connect(self.decreaseValue)        # 连接按钮信号
+        self.plusButton.clicked.connect(self.increaseValue)        # 连接按钮信号
 
     def __onValueChanged(self, value: int):
         """ slider value changed slot """
@@ -63,3 +79,13 @@ class RangeSettingCard1(SettingCard):
         self.valueLabel.setNum(value)
         self.valueLabel.adjustSize()
         self.slider.setValue(value)
+
+    def decreaseValue(self):
+        value = self.slider.value()
+        if value > self.slider.minimum():
+            self.slider.setValue(value - 1)
+
+    def increaseValue(self):
+        value = self.slider.value()
+        if value < self.slider.maximum():
+            self.slider.setValue(value + 1)


### PR DESCRIPTION
## 内容
- 修改了 app/card/rangesettingcard1.py 为GUI的设置页面存在的滑块的卡片增加了加减按钮以便更加精细的控制

## 效果图
- Before
![Before](https://github.com/user-attachments/assets/865bff3c-f30a-4cad-ad19-7237a31e3cf0 "Before")
- After
![After](https://github.com/user-attachments/assets/ad2c5ab3-287d-4264-94ed-d444e6427646 "After")