### PR TITLE
:sparkles: clear account

### DIFF
--- a/app/sub_interfaces/accounts_interface.py
+++ b/app/sub_interfaces/accounts_interface.py
@@ -9,7 +9,7 @@ from qfluentwidgets import FluentIcon as FIF
 from PyQt5.QtGui import QPalette
 from module.config import cfg
 from app.tools.account_manager import accounts, reload_all_account_from_files, dump_current_account, delete_account, \
-    save_account_name, import_account, save_acc_and_pwd
+    save_account_name, import_account, save_acc_and_pwd, clear_reg
 from module.logger import log
 
 
@@ -38,12 +38,14 @@ class AccountsCard(QFrame):
         self.renameAccountButton = QPushButton("账户更名", self)
         self.autologinAccountButton = QPushButton("自动登录", self)
         self.refreshAccountButton = QPushButton("刷新", self)
+        self.clearRegButton = QPushButton("清除注册表", self)
         self.buttons.addWidget(self.addAccountButton)
         self.buttons.addWidget(self.importAccountButton)
         self.buttons.addWidget(self.deleteAccountButton)
         self.buttons.addWidget(self.renameAccountButton)
         self.buttons.addWidget(self.autologinAccountButton)
         self.buttons.addWidget(self.refreshAccountButton)
+        self.buttons.addWidget(self.clearRegButton)
         _self = self
 
         def load_accounts():
@@ -148,12 +150,21 @@ class AccountsCard(QFrame):
                 account_id = item.data(Qt.UserRole)
                 import_account(account_id)
                 QMessageBox.information(None, "导入", "账户导入成功")
+
+        def clearRegButtonAction(self):
+            if QMessageBox.question(None, "清除注册表", "确定要清除注册表中的账户信息吗？", QMessageBox.Yes | QMessageBox.No) == QMessageBox.No:
+                return
+            clear_reg()
+            QMessageBox.information(None, "清除注册表", "注册表中的账户信息已清除")
+            
+        
         self.addAccountButton.clicked.connect(addAccountButtonAction)
         self.importAccountButton.clicked.connect(importAccountButtonAction)
         self.refreshAccountButton.clicked.connect(refreshAccountButtonAction)
         self.renameAccountButton.clicked.connect(renameAccountButtonAction)
         self.autologinAccountButton.clicked.connect(autologinAccountButtonAction)
         self.deleteAccountButton.clicked.connect(deleteAccountButtonAction)
+        self.clearRegButton.clicked.connect(clearRegButtonAction)
         #
         self.mLayout = QGridLayout()
         self.mLayout.addLayout(self.wLayout, 0, 0, 1, 1)

--- a/app/tools/account_manager.py
+++ b/app/tools/account_manager.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from utils.registry.gameaccount import gamereg_uid, gamereg_export, gamereg_import
+from utils.registry.gameaccount import gamereg_uid, gamereg_export, gamereg_import, gamereg_delete_all
 from module.logger import log
 
 data_dir = "settings/accounts"
@@ -154,3 +154,9 @@ def xor_decrypt_from_base64(encrypted_base64: str) -> str:
 
     decrypted_str = decrypted_bytes.decode('utf-8')
     return decrypted_str
+
+def clear_reg():
+    """
+    清除注册表中的账户信息
+    """
+    gamereg_delete_all()

--- a/utils/registry/gameaccount.py
+++ b/utils/registry/gameaccount.py
@@ -51,3 +51,15 @@ def gamereg_export(path: str) -> None:
 def gamereg_import(path: str) -> None:
     subcommand = f"reg import {path}"
     result = os.system(subcommand)
+
+def gamereg_delete_all() -> None:
+    """
+    删除注册表中的所有账户信息
+    """
+    if full_reg_path is None:
+        return
+    subcommand = f"reg delete \"{full_reg_path}\" /f"
+    result = os.system(subcommand)
+    if result != 0:
+        raise Exception(f"Failed to delete registry key: {full_reg_path}. Error code: {result}")
+


### PR DESCRIPTION
星铁已经自己支持多账号了。

用于PC端切换账号时直接清除注册表中的信息。清除一个账号再登录新的，让注册表相互独立隔离是最好的。

亲测清除账号功能有效，并未引起其他BUG，重新导入后账号工作正常。