### PR TITLE
increase "switch_to_game" timeout

### DIFF
--- a/tasks/game/__init__.py
+++ b/tasks/game/__init__.py
@@ -84,7 +84,7 @@ def start_game():
                     raise Exception("启动游戏失败")
                 time.sleep(10)
 
-                if not wait_until(lambda: starrail.switch_to_game(), 60):
+                if not wait_until(lambda: starrail.switch_to_game(), 360):
                     starrail.restore_resolution()
                     starrail.restore_auto_hdr()
                     raise TimeoutError("切换到游戏超时")


### PR DESCRIPTION
如果游戏安装在机械硬盘 HDD 上，游戏启动后60秒左右会出现窗口卡死，疑似磁盘数据加载，数十秒后恢复。

增加切换到游戏的超时，以减少 HDD 机械硬盘用户的报错概率。
