### PR TITLE
支持执行失败后直接退出程序

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -575,6 +575,12 @@ class SettingInterface(ScrollArea):
             "新版本将更加稳定并拥有更多功能（建议启用）",
             "check_update"
         )
+        self.exitAfterFailure = SwitchSettingCard1(
+            FIF.SYNC,
+            self.tr('失败后直接退出'),
+            "如果勾选，那么失败后直接退出，否则失败后程序暂停。",
+            "exit_after_failure"
+        )
         self.afterFinishCard = ComboBoxSettingCard2(
             "after_finish",
             FIF.POWER_BUTTON,

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -7,6 +7,9 @@ log_level: INFO # 日志等级，可选值：INFO, DEBUG。INFO 仅记录重要�
 # 更新检查
 check_update: true # 是否检查更新。true 检查，false 不检查。
 
+# 失败后直接退出
+exit_after_failure: false # 是否在失败后直接退出。true 直接退出，false 暂停程序。
+
 # 任务完成后操作
 after_finish: None # 任务完成后的操作，可选值："None"（无操作）, "Exit"（退出程序）, "Loop"（循环执行）, "Shutdown"（关机）, "Sleep"（睡眠）, "Hibernate"（休眠）, "Restart"（重启）, "Logoff"（注销）。
 

--- a/main.py
+++ b/main.py
@@ -142,10 +142,12 @@ if __name__ == "__main__":
         main(sys.argv[1]) if len(sys.argv) > 1 else main()
     except KeyboardInterrupt:
         log.error("发生错误: 手动强制停止")
-        input("按回车键关闭窗口. . .")
+        if not cfg.exit_after_failure:
+            input("按回车键关闭窗口. . .")
         sys.exit(1)
     except Exception as e:
         log.error(cfg.notify_template['ErrorOccurred'].format(error=e))
         notif.notify(cfg.notify_template['ErrorOccurred'].format(error=e))
-        input("按回车键关闭窗口. . .")
+        if not cfg.exit_after_failure:
+            input("按回车键关闭窗口. . .")
         sys.exit(1)


### PR DESCRIPTION
现在执行逻辑是，执行失败时用stdin卡住控制台。这种方式不适合无人值守的情况。

这个 PR 旨在添加一个配置，使得用户可以让程序执行失败后直接退出。
