### PR TITLE
使用SMTP发送通知时，支持不使用用户名选项

### DIFF
--- a/module/notification/smtp.py
+++ b/module/notification/smtp.py
@@ -44,7 +44,8 @@ class SMTPNotifier(Notifier):
             smtp = smtplib.SMTP_SSL(host, port, context=sslcontext(ssl_unverified))
         else:
             smtp = smtplib.SMTP(host, port)
-        smtp.login(user, password)
+        if user != '':
+            smtp.login(user, password)
         smtp.sendmail(From, To, msg.as_string())
         smtp.quit()
 


### PR DESCRIPTION
使用SMTP发送通知时，支持不使用用户名选项

有些SMTP邮件服务器不需要使用用户名和密码或授权码登录，即可直接发送邮件。
支持不使用用户名选项还可以做到以下的效果：
直接用MX服务器（例如mx1.qq.com）作为SMTP服务器发邮件到自己的邮箱，mx1.qq.com不支持用户名和密码登录，只需要一个邮箱地址即可