### PR TITLE
使用SMTP发送通知时，支持不使用用户名选项(修复bug)

### DIFF
--- a/module/notification/smtp.py
+++ b/module/notification/smtp.py
@@ -13,8 +13,8 @@ class SMTPNotifier(Notifier):
 
     def send(self, title: str, content: str, image_io=None):
         host = self.params["host"]
-        user = self.params["user"]
-        password = self.params["password"]
+        user = self.params.get("user", '')
+        password = self.params.get("password", '')
         From = self.params.get("From", user)
         To = self.params.get("To", user)
         port = self.params.get("port", 465)


### PR DESCRIPTION
使用SMTP发送通知时，支持不使用用户名选项(修复bug)

修复使用SMTP发送通知时，不使用用户名选项会抛出异常的bug