### PR TITLE
Fix：bugfix_658 修复角色选取问题

### DIFF
--- a/tasks/challenge/basechallenge.py
+++ b/tasks/challenge/basechallenge.py
@@ -74,20 +74,26 @@ class BaseChallenge(ABC):
             auto.take_screenshot(crop=(30 / 1920, 115 / 1080, 530 / 1920, 810 / 1080))
             # 选择角色
             for character in team_config:
-                if not auto.click_element(f"./assets/images/share/character/{character[0]}.png", "image", 0.7, max_retries=10, take_screenshot=False):
-                    # 尝试向下滚动
-                    auto.click_element("等级", "text", include=True, action="move")
-                    auto.mouse_scroll(26, -1, False)
-                    time.sleep(1)
-                    auto.click_element("角色列表", "text", include=True, action="move")
-                    if not auto.click_element(f"./assets/images/share/character/{character[0]}.png", "image", 0.7, max_retries=10, take_screenshot=False):
+                scrolling_counter = 0 #统计滚动次数
+                max_scroll_times = 4 #最大滚动次数
+                scroll_line = 19 #26滚动1页，13滚动半页
+                while(not auto.click_element(f"./assets/images/share/character/{character[0]}.png", "image", 0.7, max_retries=10, take_screenshot=False)):
+                    if scrolling_counter > max_scroll_times:
+                        #滚动超过2页强制结束
+                        log.info(f"{character[0]}未找到")
                         return False
-                    else:
-                        # 尝试向上滚动 恢复初始位置
-                        auto.click_element("等级", "text", include=True, action="move")
-                        auto.mouse_scroll(26, 1, False)
-                        time.sleep(1)
-                        auto.click_element("角色列表", "text", include=True, action="move")
+                    auto.click_element("等级", "text", include=True, action="move")
+                    #，尝试向下滚动
+                    auto.mouse_scroll(scroll_line, -1, False)
+                    time.sleep(0.5)
+                    auto.click_element("角色列表", "text", include=True, action="move")
+                    scrolling_counter += 1
+                for _ in range(scrolling_counter):
+                     # 尝试向上滚动 恢复初始位置
+                    auto.click_element("等级", "text", include=True, action="move")
+                    auto.mouse_scroll(scroll_line, 1, False)
+                    time.sleep(0.5)
+                    auto.click_element("角色列表", "text", include=True, action="move")
                 time.sleep(0.5)
             return True
         return False


### PR DESCRIPTION
#658 #746 脚本运行到混沌，末日或者虚构时，角色选取会因为上下滑动距离过大 刚好卡一排四个角色无法识别选取。进而无法自动运行混沌，末日或者虚构。

解决方案：
调整滑动选人范围，加入选人失败LOG。
选人滚动范围限定为2页稍多（比原方案多1页）。