### PR TITLE
fix：修复清体力前自动判断是否使用支援角色特性

### DIFF
--- a/tasks/daily/daily.py
+++ b/tasks/daily/daily.py
@@ -114,15 +114,20 @@ class Daily:
 
         cfg.set_value("daily_tasks", tasks.daily_tasks)
         log.hr("日常任务查询完成", 2)
-
+    
     @staticmethod
     def run():
         log.hr("开始日常任务", 0)
-        if Date.is_next_x_am(cfg.last_run_timestamp, cfg.refresh_hour): # 需要查第二次检查清体力完成了什么
+        # 先清空，日常任务还没刷新前，避免残留未完成任务导致异常
+        empty_tasks = []
+        cfg.set_value("daily_tasks", empty_tasks)
+        # 再次查任务列表，用于检查清体力后完成了什么
+        if Date.is_next_x_am(cfg.last_run_timestamp, cfg.refresh_hour): 
             Daily.lookup()
             cfg.save_timestamp("last_run_timestamp")
         else:
             log.info("日常任务尚未刷新")
+
         if len(cfg.daily_tasks) > 0:
             task_functions = {
                 "登录游戏": (lambda: True, 100),
@@ -192,6 +197,6 @@ class Daily:
                         log.info(f"完成任务: {task_name} (+{green(f'{score}')}分)，当前分数: {yellow(f'{current_score}/{TARGET_SCORE}')}")
                     else:
                         log.info(f"任务无法完成: {task_name}")
-            empty_tasks = []
-            cfg.set_value("daily_tasks", empty_tasks) # 清空日常任务，避免提前结束cfg中存在未完成任务导致出现异常
+            # 清空日常任务，避免由于提前结束，而cfg中残留未完成任务导致出现异常
+            cfg.set_value("daily_tasks", empty_tasks) 
         log.hr("完成", 2)


### PR DESCRIPTION
如标题所示，修复清体力前自动判断是否使用支援角色特性。
发现调整运行顺序确实还是会产生一点影响的，再次调整了一下运行顺序。（没有ISSUE）
commit了好多次，总之解释一下原因：
第一次：修复清体力前自动判断是否使用支援角色特性
第二次：发现又引入了清完体力后，未判断实训情况是否更新的bug，修复
第三次：发现时间戳更新位置，会导致同第二次的情况，修复
第四次：发现同一天内两次完整运行时，会由于查支援是否使用情况导致仍旧会运行，修复

以上，已经想不到还有什么变化了，看最终结果的commit就行了。
