### PR TITLE
feat: 云·星穹铁道兼容配置项“启用检测自动战斗”

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -797,7 +797,7 @@ class SettingInterface(ScrollArea):
         self.autoBattleDetectEnableCard = SwitchSettingCard1(
             FIF.ROBOT,
             self.tr('启用自动战斗检测'),
-            "（不支持云·星穹铁道）只对清体力和逐光捡金场景生效，并在启动游戏前自动检测并修改注册表值",
+            "游戏启动前通过修改注册表或本地存储开启自动战斗，并在清体力和逐光捡金场景中检测并保持自动战斗状态",
             "auto_battle_detect_enable"
         )
         self.autoSetResolutionEnableCard = SwitchSettingCard1(


### PR DESCRIPTION
原理：云游戏的配置存储在 local storage，通过修改 local storage 来在进入云游戏前开启自动战斗

其实在之前，云·星穹铁道已经支持在战斗中检测自动战斗，只是不支持在进入云游戏前开启自动战斗