### PR TITLE
fix: 将小灯泡识别阈值提高到 50000

### DIFF
--- a/tasks/challenge/memoryofchaos.py
+++ b/tasks/challenge/memoryofchaos.py
@@ -180,7 +180,7 @@ class MemoryOfChaos(BaseChallenge):
         start_time = time.time()
         while time.time() - start_time < timeout:
             # 整间完成
-            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 30000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
+            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 50000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
                 return True
             elif auto.find_element("./assets/images/forgottenhall/back.png", "image", 0.9):
                 time.sleep(2)

--- a/tasks/challenge/memoryone.py
+++ b/tasks/challenge/memoryone.py
@@ -104,7 +104,7 @@ class MemoryOne(BaseChallenge):
         start_time = time.time()
         while time.time() - start_time < timeout:
             # 整间完成
-            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 30000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
+            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 50000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
                 return True
             elif auto.find_element("./assets/images/forgottenhall/back.png", "image", 0.9):
                 # 挑战失败

--- a/tasks/challenge/purefiction.py
+++ b/tasks/challenge/purefiction.py
@@ -188,7 +188,7 @@ class PureFiction(BaseChallenge):
         start_time = time.time()
         while time.time() - start_time < timeout:
             # 整间完成
-            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 30000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
+            if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 50000, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
                 return True
             elif auto.find_element("./assets/images/purefiction/back.png", "image", 0.9):
                 # 挑战失败

--- a/tasks/power/instance.py
+++ b/tasks/power/instance.py
@@ -205,7 +205,7 @@ class Instance:
                         return False
                     time.sleep(0.1)
 
-                if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 30000, max_retries=60, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
+                if auto.find_element("./assets/images/purefiction/prepare_fight.png", "image", 50000, max_retries=60, crop=(0 / 1920, 0 / 1080, 300.0 / 1920, 300.0 / 1080)):
                     time.sleep(1)
 
                     # 使用秘技


### PR DESCRIPTION
问题：云游戏画面不稳定，图标会有点模糊，小灯泡识别失败，导致饰品提取失败。
```
2025-12-04 04:05:41,555 | DEBUG | 目标图片：purefiction/prepare_fight.png 相似度：37467.00 匹配阈值：30000
```

解决：将小灯泡识别阈值提高到 50000，经测试，50000 仍是比较准确的阈值

<img width="740" height="211" alt="image" src="https://github.com/user-attachments/assets/42ed96dd-cc53-439a-b4b3-119c37cc505b" />

此外，在 #650 中，稍微有一点色差都会导致相似度飙升到 20w 以上，这个也可以证明，50000 是比较准确的阈值