### PR TITLE
feat: 下载浏览器和驱动时使用国内镜像源

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -634,7 +634,6 @@ class SettingInterface(ScrollArea):
             None,
             "cloud_game_fullscreen_enable"
         )
-
         self.cloudGameMaxQueueTimeCard = RangeSettingCard1(
             "cloud_game_max_queue_time",
             [1, 60],
@@ -642,7 +641,12 @@ class SettingInterface(ScrollArea):
             self.tr("最大排队等待时间（分钟）"),
             ''
         )
-
+        self.browserDownloadUseMirrorCard = SwitchSettingCard1(
+            FIF.CLOUD_DOWNLOAD,
+            self.tr("使用国内镜像下载浏览器和驱动"),
+            None,
+            "browser_download_use_mirror"
+        )
         # self.cloudGameVideoQualityCard = ComboBoxSettingCard2(
         #     "cloud_game_video_quality",
         #     FIF.VIDEO,
@@ -650,14 +654,12 @@ class SettingInterface(ScrollArea):
         #     None,
         #     texts={"超高清": "0", "高清": "1", "标清": "2", "低清": "3"}
         # )
-
         # self.cloudGameSmoothFirstCard = SwitchSettingCard1(
         #     FIF.SPEED_HIGH,
         #     self.tr("画面流畅优先"),
         #     "启用这个选项后，当网速过慢时，会自动调低画质",
         #     "cloud_game_smooth_first_enable"
         # )
-
         # self.cloudGameShowStatusCard = SwitchSettingCardCloudGameStatus(
         #     FIF.INFO,
         #     self.tr("云游戏内显示网络状态"),
@@ -665,7 +667,6 @@ class SettingInterface(ScrollArea):
         #     "cloud_game_status_bar_enable",
         #     "cloud_game_status_bar_type"
         # )
-
         self.browserTypeCard = ComboBoxSettingCard2(
             "browser_type",
             FIF.GLOBE,
@@ -673,35 +674,32 @@ class SettingInterface(ScrollArea):
             self.tr("‘集成’ 模式下，会自动下载浏览器"),
             {"集成（Chrome For Testing）": "integrated", "Chrome": "chrome", "Edge": "edge"}
         )
-
         self.browserHeadlessCard = SwitchSettingCard1(
             FIF.VIEW,
             self.tr("无窗口模式（后台运行）"),
             self.tr("不支持模拟宇宙和锄大地"),
             "browser_headless_enable"
         )
-
         # self.browserCookiesCard = SwitchSettingCard1(
         #     FIF.PALETTE,    # 这个画盘长得很像 Cookie
         #     self.tr("保存 Cookies（登录状态）"),
         #     None,
         #     "browser_dump_cookies_enable"
         # )
-
         self.browserPersistentCard = SwitchSettingCard1(
             FIF.DOWNLOAD,
             self.tr("保存浏览器数据（游戏的登录状态和本地数据）"),
             None,
             "browser_persistent_enable"
         )
-
-        self.browserScaleCard = PushSettingCardEval(
-            self.tr("修改"),
+        self.browserScaleCard = ComboBoxSettingCard2(
+            "browser_scale_factor",
             FIF.ZOOM,
-            self.tr("浏览器缩放比例（如果画面过小/过大，可适当增加/减少这个值）"),
-            "browser_scale_factor"
+            self.tr("浏览器画面缩放（DPI）"),
+            self.tr("非 1920x1080 屏幕下，云游戏画面无法铺满屏幕，可以调整这个值改变画面缩放"),
+            texts={'50%': 0.5, '67%': 0.67, '75%': 0.75, '80%': 0.80, '90%': 0.90, '无缩放（100%）': 1.0,
+                   '110%': 1.10,'125%': 1.25, '150%': 1.5, '175%': 1.75, '200%': 2.0}
         )
-
         self.browserLaunchArgCard = PushSettingCardEval(
             self.tr("修改"),
             FIF.CODE,
@@ -1063,6 +1061,7 @@ class SettingInterface(ScrollArea):
         ])
 
         self.CloudGameGroup.addSettingCard(self.cloudGameEnableCard)
+        self.CloudGameGroup.addSettingCard(self.browserDownloadUseMirrorCard)
         self.CloudGameGroup.addSettingCard(self.browserTypeCard)
         self.CloudGameGroup.addSettingCard(self.cloudGameFullScreenCard)
         self.CloudGameGroup.addSettingCard(self.browserHeadlessCard)

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -55,6 +55,11 @@ browser_persistent_enable: True # 是否允许浏览器保存数据（登录状�
 browser_scale_factor: 1.0 # 浏览器的缩放比，如果云游戏画面过小/过大，可调整这个选项
 browser_launch_argument: [] # 浏览器启动的额外参数，如 "--auto-open-devtools-for-tabs"
 browser_debug_port: 9222 # 浏览器 Debug 端口，应确保该端口不被占用
+browser_download_use_mirror: True # 是否使用镜像下载浏览器和驱动
+browser_mirror_urls:
+  chrome: https://registry.npmmirror.com/-/binary/chrome-for-testing/
+  chromedriver: https://registry.npmmirror.com/-/binary/chrome-for-testing/
+  edgedriver: https://registry.npmmirror.com/-/binary/edgedriver/
 
 # 副本设置
 instance_type: 拟造花萼（金） # 设置副本类型，可选值：拟造花萼（金）、拟造花萼（赤）、凝滞虚影、侵蚀隧洞、饰品提取。

--- a/module/game/cloud.py
+++ b/module/game/cloud.py
@@ -93,14 +93,21 @@ class CloudGameController(GameControllerBase):
             browser_path = self.INTEGRATED_BROWSER_PATH
             driver_path = self.INTEGRATED_DRIVER_PATH
             if not os.path.exists(browser_path) or not os.path.exists(driver_path):
-                self.log_info("正在下载浏览器和驱动...")
                 args = ["--browser", browser_type,
                         "--cache-path", self.BROWSER_INSTALL_PATH,
                         "--browser-version", self.INTEGRATED_BROWSER_VERSION,
                         "--force-browser-download",
                         "--skip-driver-in-path",
                         "--skip-browser-in-path"]
+                if self.cfg.browser_download_use_mirror:
+                    self.log_info(f"正在使用镜像源，浏览器镜像源：{self.cfg.browser_mirror_urls['chrome']}，"
+                                  f"驱动镜像源：{self.cfg.browser_mirror_urls['chromedriver']}")
+                    args.extend([
+                        "--browser-mirror-url", self.cfg.browser_mirror_urls["chrome"],
+                        "--driver-mirror-url", self.cfg.browser_mirror_urls["chromedriver"],
+                    ])
                 try:
+                    self.log_info("正在下载浏览器和驱动...")
                     SeleniumManager().binary_paths(args)
                 except WebDriverException as e:
                     raise Exception(f"浏览器和驱动下载失败：{e}")
@@ -110,6 +117,15 @@ class CloudGameController(GameControllerBase):
                     "--cache-path", self.BROWSER_INSTALL_PATH,
                     "--avoid-browser-download",
                     "--skip-driver-in-path"]
+            if self.cfg.browser_download_use_mirror:
+                if browser_type == "chrome":
+                    args.extend([
+                        "--driver-mirror-url", self.cfg.browser_mirror_urls["chromedriver"]
+                    ])
+                elif browser_type == "edge":
+                    args.extend([
+                        "--driver-mirror-url", self.cfg.browser_mirror_urls["edgedriver"]
+                    ])
             try:
                 result = SeleniumManager().binary_paths(args)
             except WebDriverException as e:
@@ -198,6 +214,7 @@ class CloudGameController(GameControllerBase):
             self.log_error("如果仍然存在问题，请更换浏览器重试")
             raise Exception("浏览器启动失败")
         
+        self.driver.set_window_size(1920, 1120)
         if first_run or not self.cfg.browser_persistent_enable:
             self._load_initial_local_storage()
         if self.cfg.auto_battle_detect_enable:


### PR DESCRIPTION
为国内用户添加浏览器/驱动镜像下载功能 #791：

  - ✅ 新增镜像源开关和配置
  - ✅ 使用 npmmirror 镜像加速下载
  - ✅ 支持 Chrome/Edge 浏览器
 
其他改动：
  - ✅ 改进 UI，浏览器缩放下拉选择
  - ✅ 删除多余空行