### PR TITLE
fix: 修复前台浏览器未正常关闭的问题

### DIFF
--- a/module/game/cloud.py
+++ b/module/game/cloud.py
@@ -415,7 +415,7 @@ class CloudGameController(GameControllerBase):
         for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
             if proc.info['name'] in ('chrome.exe', 'msedge.exe'):
                 cmdline = proc.info['cmdline']
-                if self.BROWSER_TAG in cmdline and (headless is None or (headless and "--headless=new" in cmdline)):
+                if self.BROWSER_TAG in cmdline and (headless is None or (headless == ("--headless=new" in cmdline))):
                     all_proc.append(proc)
         return all_proc
                     

--- a/tasks/game/__init__.py
+++ b/tasks/game/__init__.py
@@ -157,6 +157,7 @@ def start_game():
             # time.sleep(10)    #dont need to wait
             if not wait_until(lambda: cloud_game_check_and_enter(), 600):
                 raise TimeoutError("查找并点击进入按钮超时")
+            time.sleep(10)
 
     for retry in range(MAX_RETRY):
         try:


### PR DESCRIPTION
此外，还顺带修复了另一个小问题：点击”进入游戏“后，这时候会有 10 秒左右检测不到游戏界面类型，会一直报 warning直到载入游戏。修复方案是，等 10 秒后再检测界面