### PR TITLE
fix: 修复队伍有空位时使用支援角色误移除最后一位角色的问题

### DIFF
--- a/tasks/power/character.py
+++ b/tasks/power/character.py
@@ -156,6 +156,6 @@ class Character:
         auto.press_key("esc")
         time.sleep(1)
         if type == "standard":
-            auto.find_element("支援", "text", max_retries=10, crop=(1670 / 1920, 700 / 1080, 225 / 1920, 74 / 1080))
+            auto.find_element("支援", "text", max_retries=10, crop=(966 / 1920, 954 / 1080, 176 / 1920, 60 / 1080))
         elif type == "ornament":
-            auto.find_element("支援", "text", max_retries=10, crop=(876.0 / 1920, 868.0 / 1080, 155.0 / 1920, 54.0 / 1080))
+            auto.find_element("支援", "text", max_retries=10, crop=(610 / 1920, 864 / 1080, 184 / 1920, 64 / 1080))


### PR DESCRIPTION
修改：
- 只有在确认队伍已满的情况下才会踢出最后一位角色。
- 补齐了 0bd556d 中忘记同步更新的 crop（`exit_support_list`）。

相关问题：
- #899 