### PR TITLE
✨ Quality: Add command-line argument for forcing 1920*1080 resolution

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,11 @@ def parse_args():
         action="store_true",
         help="不隐藏控制台窗口，显示命令行输出（仅 Windows）"
     )
+    optional.add_argument(
+        "--force-1080p",
+        action="store_true",
+        help="强制设置游戏分辨率为 1920x1080"
+    )
 
     args = parser.parse_args()
 
@@ -76,8 +81,16 @@ def parse_args():
     return args
 
 
+def apply_force_1080p():
+    """如果指定了 --force-1080p 参数，则强制设置游戏分辨率为 1920x1080"""
+    if args.force_1080p:
+        os.environ['MARCH7TH_RESOLUTION_WIDTH'] = '1920'
+        os.environ['MARCH7TH_RESOLUTION_HEIGHT'] = '1080'
+
+
 # 解析命令行参数（在请求管理员权限之前）
 args = parse_args()
+apply_force_1080p()
 
 # 如果不需要命令行输出，隐藏控制台窗口
 if not args.no_silent:


### PR DESCRIPTION
## ✨ Code Quality

### Problem
Add a new command-line argument `--force-1080p` that when provided, forces the game resolution to 1920*1080 by setting an environment variable that overrides the config.

**Severity**: `medium`
**File**: `app.py`

### Solution
Add a new command-line argument `--force-1080p` that when provided, forces the game resolution to 1920*1080 by setting an environment variable that overrides the config.

### Changes
- `app.py` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #919