### PR TITLE
Security: Command injection via unquoted shell command arguments in registry import/export

### DIFF
--- a/utils/registry/gameaccount.py
+++ b/utils/registry/gameaccount.py
@@ -1,5 +1,5 @@
-import os
 import sys
+import subprocess
 if sys.platform == 'win32':
     import winreg
 import itertools
@@ -48,15 +48,22 @@ def gamereg_uid() -> int | None:
         return None
 
 
+def _validate_reg_path(path: str) -> None:
+    if not path.lower().endswith('.reg'):
+        raise ValueError("Invalid registry file path")
+    if any(char in path for char in ('&', '|', ';', '>', '<')):
+        raise ValueError("Invalid registry file path")
+
+
 def gamereg_export(path: str) -> None:
     if full_reg_path is not None:
-        subcommand = f"reg export \"{full_reg_path}\" {path} /y"
-        result = os.system(subcommand)
+        _validate_reg_path(path)
+        subprocess.run(["reg", "export", full_reg_path, path, "/y"], check=False)
 
 
 def gamereg_import(path: str) -> None:
-    subcommand = f"reg import {path}"
-    result = os.system(subcommand)
+    _validate_reg_path(path)
+    subprocess.run(["reg", "import", path], check=False)
 
 
 def gamereg_delete_all() -> None:


### PR DESCRIPTION
## Summary

Security: Command injection via unquoted shell command arguments in registry import/export

## Problem

**Severity**: `High` | **File**: `utils/registry/gameaccount.py:L49`

The functions `gamereg_export()` and `gamereg_import()` build shell commands using f-strings and execute them with `os.system()`. The `path` argument is not safely quoted/escaped, so a crafted value (e.g., containing `&`, `|`, or other shell metacharacters) could execute arbitrary commands on Windows.

## Solution

Avoid `os.system()` for command execution. Use `subprocess.run()` with an argument list and `shell=False`, e.g., `subprocess.run(["reg", "import", path], check=True)`. Validate that `path` points to an expected `.reg` file and reject dangerous characters.

## Changes

- `utils/registry/gameaccount.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.0.0*