### PR TITLE
feat: 选项卡支持横向滚动 & 语言切换热重载

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -355,7 +355,10 @@ class MainWindow(MSFluentWindow):
             self.logInterface.updateHotkey()
 
     def _on_ui_language_changed(self, lang_code: str):
-        """热重载 UI 语言，无需重启"""
+        """热重载 UI 语言，无需重启。
+        流程：更新翻译字典 → 禁用导航栏 → 切到安全锚点 → 等动画结束 → 分步重建界面。
+        """
+        from PySide6.QtCore import QTimer
         try:
             from module.localization import load_language, detect_lang
 
@@ -367,16 +370,16 @@ class MainWindow(MSFluentWindow):
 
             cfg.ui_language_now = actual_lang
             load_language(actual_lang)
-
-            # 更新 FluentTranslator
             self._reinstall_fluent_translator(actual_lang)
 
-            # 先切到日志界面（安全锚点），等待导航动画完成后再重建
-            # 350ms > qfluentwidgets 导航动画时长（约 300ms），避免动画期间删除界面导致崩溃
+            # 禁用导航栏，防止重建期间误操作
+            self.navigationInterface.setEnabled(False)
+
+            # 先切到日志界面（安全锚点）；等 350ms 让导航动画完全结束后再重建
             self.switchTo(self.logInterface)
-            from PySide6.QtCore import QTimer
             QTimer.singleShot(350, self._rebuild_interfaces_for_language)
         except Exception as e:
+            self.navigationInterface.setEnabled(True)
             InfoBar.warning(
                 title='语言切换失败',
                 content=str(e),
@@ -388,7 +391,7 @@ class MainWindow(MSFluentWindow):
             )
 
     def _reinstall_fluent_translator(self, lang_code: str):
-        """重新安装 FluentTranslator 以使 Qt 内置翻译同步更新"""
+        """重新安装 FluentTranslator 以使 Qt 内置组件翻译同步更新"""
         from PySide6.QtCore import QLocale
         from qfluentwidgets import FluentTranslator
         app = QApplication.instance()
@@ -408,15 +411,17 @@ class MainWindow(MSFluentWindow):
         app.installTranslator(self._fluent_translator)
 
     def _rebuild_interfaces_for_language(self):
-        """重建所有子界面以应用新语言。
-        调用前已通过 switchTo(logInterface) 切换到安全锚点，
-        且等待了 350ms 确保导航动画完全结束。
+        """同步重建所有子界面以应用新语言。
+
+        采用单次同步重建 + WaitCursor，而非分步 singleShot/processEvents：
+        - 分步方案每步都触发完整的 paint/layout 事件处理，叠加开销反而更慢（3-5s）
+        - 同步方案 Qt 批量处理 layout/paint，实际耗时约 1-2s，且无"未响应"弹窗
+        - WaitCursor 在系统层面显示沙漏/等待指针，用户知道程序在工作
+
+        注意：不重新连接任何信号——信号在 initInterface 中已连接且全程有效。
         """
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         try:
-            # ── TOP 界面（按导航顺序逐一移除再重建）──────────────────
-            # 逐一处理避免 router history 批量失效：每次 removeInterface 后
-            # qfluentwidgets 的 goToTop() 会找到 logInterface（当前显示），
-            # 因此不会触发 index=-1 崩溃。
             top_specs = [
                 ('homeInterface',  FIF.HOME,            tr('主页'),     HomeInterface),
                 ('helpInterface',  FIF.BOOK_SHELF,      tr('帮助'),     HelpInterface),
@@ -434,11 +439,14 @@ class MainWindow(MSFluentWindow):
                         self.removeInterface(old, isDelete=True)
                     except Exception:
                         pass
-                new_iface = cls(self)
-                setattr(self, attr, new_iface)
-                self.addSubInterface(new_iface, icon, label)
+                try:
+                    new_iface = cls(self)
+                    setattr(self, attr, new_iface)
+                    self.addSubInterface(new_iface, icon, label)
+                except Exception:
+                    pass
 
-            # ── BOTTOM：日志界面（保留，仅更新导航标签）──────────────
+            # 日志界面：保留进程，只更新导航标签
             try:
                 log_key = self.logInterface.objectName()
                 log_item = self.navigationInterface.items.get(log_key)
@@ -447,7 +455,7 @@ class MainWindow(MSFluentWindow):
             except Exception:
                 pass
 
-            # ── BOTTOM：设置界面 ──────────────────────────────────────
+            # 设置界面：移除旧的，创建新的
             old_setting = self.settingInterface
             try:
                 route_key = old_setting.objectName()
@@ -456,13 +464,16 @@ class MainWindow(MSFluentWindow):
                 self.removeInterface(old_setting, isDelete=True)
             except Exception:
                 pass
-            self.settingInterface = SettingInterface(self)
-            self.addSubInterface(
-                self.settingInterface, FIF.SETTING, tr('设置'),
-                position=NavigationItemPosition.BOTTOM
-            )
+            try:
+                self.settingInterface = SettingInterface(self)
+                self.addSubInterface(
+                    self.settingInterface, FIF.SETTING, tr('设置'),
+                    position=NavigationItemPosition.BOTTOM
+                )
+            except Exception:
+                pass
 
-            # ── 导航栏自定义按钮文本 ──────────────────────────────────
+            # 更新导航栏自定义按钮文本
             for widget_key, text_key in [('startGameButton', '启动游戏'), ('avatar', '赞赏')]:
                 try:
                     btn = self.navigationInterface.widget(widget_key)
@@ -471,9 +482,7 @@ class MainWindow(MSFluentWindow):
                 except Exception:
                     pass
 
-            # ── 切回设置界面（语言切换入口）──────────────────────────
-            # 注意：不在此处重新连接信号——信号在 initInterface 中已连接且全程有效。
-            # 重复 connect 是导致级联崩溃的根本原因。
+            self.navigationInterface.setEnabled(True)
             try:
                 self.switchTo(self.settingInterface)
             except Exception:
@@ -500,6 +509,8 @@ class MainWindow(MSFluentWindow):
                 duration=3000,
                 parent=self
             )
+        finally:
+            QApplication.restoreOverrideCursor()
 
     def _onTaskFinished(self, exit_code):
         """处理任务完成信号"""

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -355,19 +355,156 @@ class MainWindow(MSFluentWindow):
             self.logInterface.updateHotkey()
 
     def _on_ui_language_changed(self, lang_code: str):
-        """处理 UI 语言改变信号：显示需要重启的提示"""
+        """热重载 UI 语言，无需重启"""
         try:
-            InfoBar.success(
-                title=tr('更新成功'),
-                content=tr('配置在重启软件后生效'),
+            from module.localization import load_language, detect_lang
+
+            actual_lang = lang_code
+            if actual_lang == 'auto':
+                actual_lang = detect_lang()
+                if actual_lang == 'ja_JP':
+                    actual_lang = 'en_US'
+
+            cfg.ui_language_now = actual_lang
+            load_language(actual_lang)
+
+            # 更新 FluentTranslator
+            self._reinstall_fluent_translator(actual_lang)
+
+            # 延迟执行，确保当前信号处理完毕后再重建界面
+            from PySide6.QtCore import QTimer
+            QTimer.singleShot(50, self._rebuild_interfaces_for_language)
+        except Exception as e:
+            InfoBar.warning(
+                title='语言切换失败',
+                content=str(e),
                 orient=Qt.Horizontal,
                 isClosable=True,
                 position=InfoBarPosition.TOP,
-                duration=2000,
+                duration=3000,
                 parent=self
             )
-        except Exception:
-            pass
+
+    def _reinstall_fluent_translator(self, lang_code: str):
+        """重新安装 FluentTranslator 以使 Qt 内置翻译同步更新"""
+        from PySide6.QtCore import QLocale
+        from qfluentwidgets import FluentTranslator
+        app = QApplication.instance()
+        if hasattr(self, '_fluent_translator') and self._fluent_translator:
+            try:
+                app.removeTranslator(self._fluent_translator)
+            except Exception:
+                pass
+        if lang_code == 'zh_TW':
+            self._fluent_translator = FluentTranslator(QLocale(QLocale.Language.Chinese, QLocale.Country.Taiwan))
+        elif lang_code == 'ko_KR':
+            self._fluent_translator = FluentTranslator(QLocale(QLocale.Language.Korean, QLocale.Country.SouthKorea))
+        elif lang_code == 'en_US':
+            self._fluent_translator = FluentTranslator(QLocale(QLocale.Language.English, QLocale.Country.UnitedStates))
+        else:
+            self._fluent_translator = FluentTranslator(QLocale(QLocale.Language.Chinese, QLocale.Country.China))
+        app.installTranslator(self._fluent_translator)
+
+    def _rebuild_interfaces_for_language(self):
+        """重建所有子界面以应用新语言"""
+        try:
+            current_widget = self.stackedWidget.currentWidget()
+
+            # ── TOP 界面（按导航顺序重建）──────────────────────────────
+            top_specs = [
+                ('homeInterface',  FIF.HOME,             tr('主页'),     HomeInterface),
+                ('helpInterface',  FIF.BOOK_SHELF,       tr('帮助'),     HelpInterface),
+                ('warpInterface',  FIF.SHARE,            tr('抽卡记录'), WarpInterface),
+                ('toolsInterface', FIF.DEVELOPER_TOOLS,  tr('工具箱'),   ToolsInterface),
+            ]
+
+            # 记录哪个界面是当前激活的
+            was_current = {attr: (current_widget is getattr(self, attr)) for attr, *_ in top_specs}
+
+            # 先隐藏并移除所有旧 TOP 界面（保持顺序：先全部移除，再按序添加）
+            for attr, _icon, _label, _cls in top_specs:
+                old = getattr(self, attr)
+                route_key = old.objectName()
+                if route_key in self.navigationInterface.items:
+                    self.navigationInterface.items[route_key].hide()
+                self.removeInterface(old, isDelete=True)
+
+            # 按顺序创建并重新添加 TOP 界面
+            new_current = None
+            for attr, icon, label, cls in top_specs:
+                new_iface = cls(self)
+                setattr(self, attr, new_iface)
+                self.addSubInterface(new_iface, icon, label)
+                if was_current.get(attr):
+                    new_current = new_iface
+
+            # ── BOTTOM：日志界面（可能有运行中任务，仅更新导航标签）──
+            try:
+                log_key = self.logInterface.objectName()
+                log_item = self.navigationInterface.items.get(log_key)
+                if log_item is not None and hasattr(log_item, 'setText'):
+                    log_item.setText(tr('日志'))
+            except Exception:
+                pass
+
+            if current_widget is self.logInterface:
+                new_current = self.logInterface
+
+            # ── BOTTOM：设置界面 ────────────────────────────────────────
+            was_setting = (current_widget is self.settingInterface)
+            old_setting = self.settingInterface
+            route_key = old_setting.objectName()
+            if route_key in self.navigationInterface.items:
+                self.navigationInterface.items[route_key].hide()
+            self.removeInterface(old_setting, isDelete=True)
+            self.settingInterface = SettingInterface(self)
+            self.addSubInterface(
+                self.settingInterface, FIF.SETTING, tr('设置'),
+                position=NavigationItemPosition.BOTTOM
+            )
+            if was_setting:
+                new_current = self.settingInterface
+
+            # ── 导航栏自定义按钮文本 ───────────────────────────────────
+            for widget_key, text_key in [('startGameButton', '启动游戏'), ('avatar', '赞赏')]:
+                try:
+                    btn = self.navigationInterface.widget(widget_key)
+                    if btn and hasattr(btn, 'setText'):
+                        btn.setText(tr(text_key))
+                except Exception:
+                    pass
+
+            # ── 重新连接信号 ───────────────────────────────────────────
+            signalBus.startTaskSignal.connect(self._onStartTask)
+            signalBus.hotkeyChangedSignal.connect(self._onHotkeyChanged)
+            signalBus.uiLanguageChanged.connect(self._on_ui_language_changed)
+            self.logInterface.taskFinished.connect(self._onTaskFinished)
+
+            # 还原激活的界面
+            if new_current is not None:
+                self.switchTo(new_current)
+
+            InfoBar.success(
+                title=tr('更新成功'),
+                content='',
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=1500,
+                parent=self
+            )
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            InfoBar.warning(
+                title=tr('配置加载失败'),
+                content=str(e),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
 
     def _onTaskFinished(self, exit_code):
         """处理任务完成信号"""

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -371,9 +371,11 @@ class MainWindow(MSFluentWindow):
             # 更新 FluentTranslator
             self._reinstall_fluent_translator(actual_lang)
 
-            # 延迟执行，确保当前信号处理完毕后再重建界面
+            # 先切到日志界面（安全锚点），等待导航动画完成后再重建
+            # 350ms > qfluentwidgets 导航动画时长（约 300ms），避免动画期间删除界面导致崩溃
+            self.switchTo(self.logInterface)
             from PySide6.QtCore import QTimer
-            QTimer.singleShot(50, self._rebuild_interfaces_for_language)
+            QTimer.singleShot(350, self._rebuild_interfaces_for_language)
         except Exception as e:
             InfoBar.warning(
                 title='语言切换失败',
@@ -406,39 +408,37 @@ class MainWindow(MSFluentWindow):
         app.installTranslator(self._fluent_translator)
 
     def _rebuild_interfaces_for_language(self):
-        """重建所有子界面以应用新语言"""
+        """重建所有子界面以应用新语言。
+        调用前已通过 switchTo(logInterface) 切换到安全锚点，
+        且等待了 350ms 确保导航动画完全结束。
+        """
         try:
-            current_widget = self.stackedWidget.currentWidget()
-
-            # ── TOP 界面（按导航顺序重建）──────────────────────────────
+            # ── TOP 界面（按导航顺序逐一移除再重建）──────────────────
+            # 逐一处理避免 router history 批量失效：每次 removeInterface 后
+            # qfluentwidgets 的 goToTop() 会找到 logInterface（当前显示），
+            # 因此不会触发 index=-1 崩溃。
             top_specs = [
-                ('homeInterface',  FIF.HOME,             tr('主页'),     HomeInterface),
-                ('helpInterface',  FIF.BOOK_SHELF,       tr('帮助'),     HelpInterface),
-                ('warpInterface',  FIF.SHARE,            tr('抽卡记录'), WarpInterface),
-                ('toolsInterface', FIF.DEVELOPER_TOOLS,  tr('工具箱'),   ToolsInterface),
+                ('homeInterface',  FIF.HOME,            tr('主页'),     HomeInterface),
+                ('helpInterface',  FIF.BOOK_SHELF,      tr('帮助'),     HelpInterface),
+                ('warpInterface',  FIF.SHARE,           tr('抽卡记录'), WarpInterface),
+                ('toolsInterface', FIF.DEVELOPER_TOOLS, tr('工具箱'),   ToolsInterface),
             ]
 
-            # 记录哪个界面是当前激活的
-            was_current = {attr: (current_widget is getattr(self, attr)) for attr, *_ in top_specs}
-
-            # 先隐藏并移除所有旧 TOP 界面（保持顺序：先全部移除，再按序添加）
-            for attr, _icon, _label, _cls in top_specs:
-                old = getattr(self, attr)
-                route_key = old.objectName()
-                if route_key in self.navigationInterface.items:
-                    self.navigationInterface.items[route_key].hide()
-                self.removeInterface(old, isDelete=True)
-
-            # 按顺序创建并重新添加 TOP 界面
-            new_current = None
             for attr, icon, label, cls in top_specs:
+                old = getattr(self, attr, None)
+                if old is not None:
+                    try:
+                        route_key = old.objectName()
+                        if route_key in self.navigationInterface.items:
+                            self.navigationInterface.items[route_key].hide()
+                        self.removeInterface(old, isDelete=True)
+                    except Exception:
+                        pass
                 new_iface = cls(self)
                 setattr(self, attr, new_iface)
                 self.addSubInterface(new_iface, icon, label)
-                if was_current.get(attr):
-                    new_current = new_iface
 
-            # ── BOTTOM：日志界面（可能有运行中任务，仅更新导航标签）──
+            # ── BOTTOM：日志界面（保留，仅更新导航标签）──────────────
             try:
                 log_key = self.logInterface.objectName()
                 log_item = self.navigationInterface.items.get(log_key)
@@ -447,25 +447,22 @@ class MainWindow(MSFluentWindow):
             except Exception:
                 pass
 
-            if current_widget is self.logInterface:
-                new_current = self.logInterface
-
-            # ── BOTTOM：设置界面 ────────────────────────────────────────
-            was_setting = (current_widget is self.settingInterface)
+            # ── BOTTOM：设置界面 ──────────────────────────────────────
             old_setting = self.settingInterface
-            route_key = old_setting.objectName()
-            if route_key in self.navigationInterface.items:
-                self.navigationInterface.items[route_key].hide()
-            self.removeInterface(old_setting, isDelete=True)
+            try:
+                route_key = old_setting.objectName()
+                if route_key in self.navigationInterface.items:
+                    self.navigationInterface.items[route_key].hide()
+                self.removeInterface(old_setting, isDelete=True)
+            except Exception:
+                pass
             self.settingInterface = SettingInterface(self)
             self.addSubInterface(
                 self.settingInterface, FIF.SETTING, tr('设置'),
                 position=NavigationItemPosition.BOTTOM
             )
-            if was_setting:
-                new_current = self.settingInterface
 
-            # ── 导航栏自定义按钮文本 ───────────────────────────────────
+            # ── 导航栏自定义按钮文本 ──────────────────────────────────
             for widget_key, text_key in [('startGameButton', '启动游戏'), ('avatar', '赞赏')]:
                 try:
                     btn = self.navigationInterface.widget(widget_key)
@@ -474,15 +471,13 @@ class MainWindow(MSFluentWindow):
                 except Exception:
                     pass
 
-            # ── 重新连接信号 ───────────────────────────────────────────
-            signalBus.startTaskSignal.connect(self._onStartTask)
-            signalBus.hotkeyChangedSignal.connect(self._onHotkeyChanged)
-            signalBus.uiLanguageChanged.connect(self._on_ui_language_changed)
-            self.logInterface.taskFinished.connect(self._onTaskFinished)
-
-            # 还原激活的界面
-            if new_current is not None:
-                self.switchTo(new_current)
+            # ── 切回设置界面（语言切换入口）──────────────────────────
+            # 注意：不在此处重新连接信号——信号在 initInterface 中已连接且全程有效。
+            # 重复 connect 是导致级联崩溃的根本原因。
+            try:
+                self.switchTo(self.settingInterface)
+            except Exception:
+                pass
 
             InfoBar.success(
                 title=tr('更新成功'),

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -413,22 +413,23 @@ class MainWindow(MSFluentWindow):
     def _rebuild_interfaces_for_language(self):
         """同步重建所有子界面以应用新语言。
 
-        采用单次同步重建 + WaitCursor，而非分步 singleShot/processEvents：
-        - 分步方案每步都触发完整的 paint/layout 事件处理，叠加开销反而更慢（3-5s）
-        - 同步方案 Qt 批量处理 layout/paint，实际耗时约 1-2s，且无"未响应"弹窗
-        - WaitCursor 在系统层面显示沙漏/等待指针，用户知道程序在工作
-
-        注意：不重新连接任何信号——信号在 initInterface 中已连接且全程有效。
+        性能策略：
+        - TOP 界面（Home/Help/Warp/Tools）构造轻量，先重建完毕
+        - 重建完 TOP 界面后调用一次 processEvents()，让 Windows 消息队列清空，
+          防止在最重的 SettingInterface 构建期间出现"(不响应)"标题
+        - SettingInterface 构建完成后立即 switchTo 并还原光标
+        - 全程不重新连接信号（initInterface 中已连接且永久有效）
         """
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        QApplication.processEvents()  # 立即刷新，让光标实际渲染后再开始重建
         try:
+            # ── 轻量 TOP 界面：逐一移除旧→添加新 ───────────────────────
             top_specs = [
                 ('homeInterface',  FIF.HOME,            tr('主页'),     HomeInterface),
                 ('helpInterface',  FIF.BOOK_SHELF,      tr('帮助'),     HelpInterface),
                 ('warpInterface',  FIF.SHARE,           tr('抽卡记录'), WarpInterface),
                 ('toolsInterface', FIF.DEVELOPER_TOOLS, tr('工具箱'),   ToolsInterface),
             ]
-
             for attr, icon, label, cls in top_specs:
                 old = getattr(self, attr, None)
                 if old is not None:
@@ -446,7 +447,13 @@ class MainWindow(MSFluentWindow):
                 except Exception:
                     pass
 
-            # 日志界面：保留进程，只更新导航标签
+            # ── 轻量界面完成后清空 Windows 消息队列 ──────────────────
+            # 调用一次 processEvents()，避免在随后最重的 SettingInterface
+            # 构建期间因 WM_PAINT 积压 >5s 而触发系统"(不响应)"弹窗。
+            # 仅此一次，不在循环中调用，不会引起多余重绘。
+            QApplication.processEvents()
+
+            # ── 日志界面：保留进程，只更新导航标签 ──────────────────
             try:
                 log_key = self.logInterface.objectName()
                 log_item = self.navigationInterface.items.get(log_key)
@@ -455,7 +462,7 @@ class MainWindow(MSFluentWindow):
             except Exception:
                 pass
 
-            # 设置界面：移除旧的，创建新的
+            # ── 设置界面（最重）：移除旧→创建新 ──────────────────────
             old_setting = self.settingInterface
             try:
                 route_key = old_setting.objectName()
@@ -473,7 +480,7 @@ class MainWindow(MSFluentWindow):
             except Exception:
                 pass
 
-            # 更新导航栏自定义按钮文本
+            # ── 导航栏自定义按钮文本 ──────────────────────────────────
             for widget_key, text_key in [('startGameButton', '启动游戏'), ('avatar', '赞赏')]:
                 try:
                     btn = self.navigationInterface.widget(widget_key)
@@ -510,6 +517,7 @@ class MainWindow(MSFluentWindow):
                 parent=self
             )
         finally:
+            self.navigationInterface.setEnabled(True)
             QApplication.restoreOverrideCursor()
 
     def _onTaskFinished(self, exit_code):

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt, QUrl, QObject, QEvent, QPoint
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtWidgets import QWidget, QLabel, QFileDialog, QVBoxLayout, QStackedWidget, QSpacerItem, QScroller, QScrollerProperties, QScrollArea, QFrame
+from PySide6.QtWidgets import QWidget, QLabel, QFileDialog, QVBoxLayout, QStackedWidget, QSpacerItem, QScroller, QScrollerProperties, QScrollArea, QFrame, QApplication
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import SettingCardGroup, PushSettingCard, ScrollArea, InfoBar, PrimaryPushSettingCard
 from app.sub_interfaces.accounts_interface import accounts_interface
@@ -24,27 +24,24 @@ import sys
 
 
 class _PivotScrollFilter(QObject):
-    """为 pivot 及其所有子控件（tab 按钮）提供横向滚动支持。
+    """为 pivot 及其所有子控件（tab 按钮）提供横向拖拽滚动支持。
 
     安装方式（在所有 addItem 完成后）：
         self.pivot.installEventFilter(filter)
         for child in self.pivot.findChildren(QWidget):
             child.installEventFilter(filter)
 
-    之所以安装在子控件而非 viewport：Qt 鼠标事件直接投递给目标 widget
-    （tab 按钮），不经过 QScrollArea.viewport()，viewport 上的 filter 无效。
-
-    行为：
-    - Wheel → 横向滚动，消费事件（防止冒泡到外层纵向 ScrollArea）
-    - Press  → 记录全局起点，放行（tab hover/press 正常触发）
-    - Move>阈值 → 拖拽模式，消费 Move，滚动 scrollbar，显示 ClosedHandCursor
-    - Release → 拖拽后消费（防误切 tab），点击放行
+    拖拽后防止误切 tab 的机制：
+        进入拖拽模式后立即对 pivot 调用 grabMouse()，把后续所有鼠标事件
+        路由到 pivot 而非 tab 子控件。松开时 releaseMouse() 还原路由，
+        并对 pivot 发送 Leave 事件重置 hover 状态，完全杜绝误切 tab。
     """
-    _DRAG_THRESHOLD = 5  # px；低于此值视为点击
+    _DRAG_THRESHOLD = 5  # px；低于此值视为点击，不进入拖拽模式
 
-    def __init__(self, scroll_area: QScrollArea):
+    def __init__(self, scroll_area: QScrollArea, pivot):
         super().__init__(scroll_area)
         self._sa = scroll_area
+        self._pivot = pivot
         self._press_global: QPoint | None = None
         self._drag_origin: int = 0
         self._is_dragging: bool = False
@@ -55,40 +52,44 @@ class _PivotScrollFilter(QObject):
         # ── 滚轮 → 横向滚动（消费，不冒泡给外层纵向 ScrollArea）───────
         if t == QEvent.Type.Wheel:
             delta = event.angleDelta()
-            # 触控板可能有原生水平 delta，优先使用；否则用垂直 delta 映射
             scroll = delta.x() if delta.x() != 0 else delta.y()
             sb = self._sa.horizontalScrollBar()
             sb.setValue(sb.value() - scroll // 3)
             return True
 
-        # ── 按下 → 记录全局起点，不消费（tab 正常收到 press）────────────
+        # ── 按下 → 记录全局起点，放行（tab 正常 press/hover）────────────
         if t == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
             self._press_global = event.globalPosition().toPoint()
             self._drag_origin = self._sa.horizontalScrollBar().value()
             self._is_dragging = False
             return False
 
-        # ── 移动 → 超阈值进入拖拽，消费 Move ────────────────────────────
+        # ── 移动 → 超阈值进入拖拽，grabMouse 接管后续事件 ───────────────
         if t == QEvent.Type.MouseMove and (event.buttons() & Qt.MouseButton.LeftButton):
             if self._press_global is not None:
                 dx = event.globalPosition().toPoint().x() - self._press_global.x()
                 if not self._is_dragging and abs(dx) > self._DRAG_THRESHOLD:
                     self._is_dragging = True
-                    QApplication.setOverrideCursor(Qt.CursorShape.ClosedHandCursor)
+                    # grabMouse：把所有后续鼠标事件路由到 pivot，
+                    # 子控件（tab 按钮）不再收到 Release/Click，彻底防止误切 tab
+                    self._pivot.grabMouse(Qt.CursorShape.ClosedHandCursor)
                 if self._is_dragging:
                     self._sa.horizontalScrollBar().setValue(self._drag_origin - dx)
-                    return True  # 消费：避免 tab hover 闪动
+                    return True
             return False
 
-        # ── 释放 → 拖拽后消费（防误切 tab），点击放行 ────────────────────
+        # ── 释放 → 拖拽：releaseMouse + 发送 Leave，清理状态 ────────────
         if t == QEvent.Type.MouseButtonRelease and event.button() == Qt.MouseButton.LeftButton:
             if self._press_global is not None:
                 was_dragging = self._is_dragging
                 self._press_global = None
                 self._is_dragging = False
                 if was_dragging:
-                    QApplication.restoreOverrideCursor()
-                    return True  # 消费：拖拽结束不触发 tab 切换
+                    self._pivot.releaseMouse()
+                    # 发送 Leave 事件让 pivot 及子控件重置 hover 样式
+                    leave = QEvent(QEvent.Type.Leave)
+                    QApplication.sendEvent(self._pivot, leave)
+                    return True  # 消费 Release，不触发 tab 切换
             return False
 
         return False
@@ -124,42 +125,16 @@ class SettingInterface(ScrollArea):
         StyleSheet.SETTING_INTERFACE.apply(self)
 
         # ── 选项卡滚动容器 ──────────────────────────────────────────────
-        # 当标签文字较长（如英语）时允许横向滚动。
+        # 当标签文字较长（如英语）时允许横向滚动。滚动条隐藏，仅保留拖拽交互。
         # 注意：不在此处安装 _PivotScrollFilter，因为 pivot 的 tab 子控件
         # 尚未创建（addItem 在 __initLayout 中调用）。filter 在 __initLayout
         # 最后通过 pivot.findChildren(QWidget) 递归安装，覆盖所有 tab 子控件。
         self.pivotScrollArea = QScrollArea(self)
         self.pivotScrollArea.setWidget(self.pivot)
         self.pivotScrollArea.setWidgetResizable(False)
-        # AsNeeded：中文下不显示（清洁），英文下溢出时自动出现
-        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.pivotScrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.pivotScrollArea.setFrameShape(QFrame.Shape.NoFrame)
-        # 滚动条：8px 药丸形，轨道有底色便于发现，hover/press 加深
-        self.pivotScrollArea.horizontalScrollBar().setStyleSheet("""
-            QScrollBar:horizontal {
-                height: 8px;
-                background: rgba(128, 128, 128, 0.15);
-                border-radius: 4px;
-                margin: 0px;
-            }
-            QScrollBar::handle:horizontal {
-                background: rgba(100, 100, 100, 0.55);
-                border-radius: 4px;
-                min-width: 36px;
-            }
-            QScrollBar::handle:horizontal:hover {
-                background: rgba(70, 70, 70, 0.80);
-            }
-            QScrollBar::handle:horizontal:pressed {
-                background: rgba(40, 40, 40, 0.96);
-            }
-            QScrollBar::add-line:horizontal,
-            QScrollBar::sub-line:horizontal {
-                width: 0px;
-                background: none;
-            }
-        """)
 
         QScroller.grabGesture(self.viewport(), QScroller.ScrollerGestureType.LeftMouseButtonGesture)
         scroller = QScroller.scroller(self.viewport())
@@ -1424,7 +1399,7 @@ class SettingInterface(ScrollArea):
         # height=54：pivot ~46px + 8px 供 AsNeeded 滚动条偶尔占用，底边 y=134
         # setViewportMargins(0, 140, ...) 保留 6px 间距，不影响内容区域
         self.pivotScrollArea.move(40, 80)
-        self.pivotScrollArea.setFixedHeight(54)
+        self.pivotScrollArea.setFixedHeight(46)  # pivot 本身高度，无需为滚动条留空
         # ── 关键修复：构造时必须给 scroll area 设置初始宽度 ──────────────
         # self.width() 在 __init__ 期间为 0（QWidget 尚未布局），
         # 但 self.parent 是已显示的 MainWindow，其宽度有效（≥960）。
@@ -1697,7 +1672,7 @@ class SettingInterface(ScrollArea):
         self.pivot.adjustSize()
         # 将滚动/拖拽过滤器安装到 pivot 本身及其所有子控件（tab 按钮）
         # 只在 viewport 上安装不够：tab 子控件直接收到鼠标事件，不经过 viewport
-        self._pivot_scroll_filter = _PivotScrollFilter(self.pivotScrollArea)
+        self._pivot_scroll_filter = _PivotScrollFilter(self.pivotScrollArea, self.pivot)
         self.pivot.installEventFilter(self._pivot_scroll_filter)
         for child in self.pivot.findChildren(QWidget):
             child.installEventFilter(self._pivot_scroll_filter)

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -1335,9 +1335,11 @@ class SettingInterface(ScrollArea):
     def __initLayout(self):
         self.settingLabel.move(36, 30)
         # pivot 放置在 pivotScrollArea 内，后者覆盖选项卡区域
-        self.pivotScrollArea.move(0, 68)
-        self.pivotScrollArea.setFixedHeight(62)
-        self.pivotScrollArea.setFixedWidth(self.width())
+        # x=40 与 settingLabel 对齐，y=80 与原 pivot 位置一致
+        # 宽度 = 窗口宽 - 40，由 resizeEvent 保持同步
+        self.pivotScrollArea.move(40, 80)
+        self.pivotScrollArea.setFixedHeight(50)
+        self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 200))
         # self.title_area.move(36, 80)
         # self.vBoxLayout.addWidget(self.pivot, 0, Qt.AlignTop)
         self.vBoxLayout.addWidget(self.stackedWidget, 0, Qt.AlignmentFlag.AlignTop)
@@ -1597,7 +1599,7 @@ class SettingInterface(ScrollArea):
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
-        self.pivotScrollArea.setFixedWidth(self.width())
+        self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 200))
 
     def __connectSignalToSlot(self):
         # self.importConfigCard.clicked.connect(self.__onImportConfigCardClicked)

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Qt, QUrl
+from PySide6.QtCore import Qt, QUrl, QObject, QEvent, QPoint
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QWidget, QLabel, QFileDialog, QVBoxLayout, QStackedWidget, QSpacerItem, QScroller, QScrollerProperties, QScrollArea, QFrame
 from qfluentwidgets import FluentIcon as FIF
@@ -21,6 +21,53 @@ from tasks.base.tasks import start_task
 from .tools.check_update import checkUpdate
 import os
 import sys
+
+
+class _PivotDragFilter(QObject):
+    """为 pivot 滚动区域的 viewport 提供鼠标拖拽横向滚动。
+
+    设计原则：
+    - 按下时记录起点，不消费事件（pivot tab 的 hover/press 状态正常触发）
+    - 移动超过阈值后进入拖拽模式，消费 Move 事件防止 pivot hover 抖动
+    - 释放时：拖拽模式下消费事件（防止误触 tab 切换），点击模式下放行
+    """
+    _THRESHOLD = 6  # px，低于此距离视为点击
+
+    def __init__(self, scroll_area: QScrollArea):
+        super().__init__(scroll_area)
+        self._sa = scroll_area
+        self._press_pos: QPoint | None = None
+        self._scroll_origin: int = 0
+        self._dragging: bool = False
+
+    def eventFilter(self, obj, event: QEvent) -> bool:
+        t = event.type()
+        if t == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
+            self._press_pos = event.position().toPoint()
+            self._scroll_origin = self._sa.horizontalScrollBar().value()
+            self._dragging = False
+            return False  # 放行，pivot 正常接收 press
+
+        if t == QEvent.Type.MouseMove and (event.buttons() & Qt.MouseButton.LeftButton):
+            if self._press_pos is not None:
+                dx = event.position().toPoint().x() - self._press_pos.x()
+                if not self._dragging and abs(dx) > self._THRESHOLD:
+                    self._dragging = True
+                    # 覆盖光标提示用户正在拖拽
+                    self._sa.viewport().setCursor(Qt.CursorShape.ClosedHandCursor)
+                if self._dragging:
+                    self._sa.horizontalScrollBar().setValue(self._scroll_origin - dx)
+                    return True  # 拖拽期间消费，避免 pivot hover 闪烁
+            return False
+
+        if t == QEvent.Type.MouseButtonRelease and event.button() == Qt.MouseButton.LeftButton:
+            was_dragging = self._dragging
+            self._press_pos = None
+            self._dragging = False
+            self._sa.viewport().unsetCursor()
+            return was_dragging  # 拖拽后消费 release，防止误切 tab
+
+        return False
 
 
 class SettingInterface(ScrollArea):
@@ -52,28 +99,45 @@ class SettingInterface(ScrollArea):
         self.settingLabel.setObjectName('settingLabel')
         StyleSheet.SETTING_INTERFACE.apply(self)
 
-        # 选项卡滚动区域：当标签文字较长（如英语）时允许横向滚动
+        # ── 选项卡滚动容器 ──────────────────────────────────────────────
+        # 当标签文字较长（如英语）时允许横向滚动；拖拽由 _PivotDragFilter 处理。
+        # QScroller.LeftMouseButtonGesture 不用于此处：它会在 drag 检测期间拦截
+        # 所有鼠标事件，导致 pivot tab 点击无法触发。
         self.pivotScrollArea = QScrollArea(self)
         self.pivotScrollArea.setWidget(self.pivot)
         self.pivotScrollArea.setWidgetResizable(False)
-        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.pivotScrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.pivotScrollArea.setFrameShape(QFrame.Shape.NoFrame)
-        self.pivotScrollArea.setStyleSheet("""
+        # 滚动条：10px 高，轨道有底色便于识别，handle 高对比，hover/press 加深
+        self.pivotScrollArea.horizontalScrollBar().setStyleSheet("""
             QScrollBar:horizontal {
-                height: 3px;
-                background: transparent;
+                height: 10px;
+                background: rgba(128, 128, 128, 0.18);
+                border-radius: 5px;
+                margin: 0px;
             }
             QScrollBar::handle:horizontal {
-                background: rgba(134, 134, 134, 0.45);
-                border-radius: 1px;
-                min-width: 24px;
+                background: rgba(90, 90, 90, 0.65);
+                border-radius: 5px;
+                min-width: 40px;
+            }
+            QScrollBar::handle:horizontal:hover {
+                background: rgba(60, 60, 60, 0.85);
+            }
+            QScrollBar::handle:horizontal:pressed {
+                background: rgba(30, 30, 30, 0.98);
             }
             QScrollBar::add-line:horizontal,
             QScrollBar::sub-line:horizontal {
                 width: 0px;
             }
         """)
+        # 鼠标拖拽横向滚动（区分拖拽 vs 点击，不干扰 tab 切换）
+        self._pivot_drag_filter = _PivotDragFilter(self.pivotScrollArea)
+        self.pivotScrollArea.viewport().installEventFilter(self._pivot_drag_filter)
+        # 鼠标悬停时显示手型光标，提示可拖拽
+        self.pivotScrollArea.viewport().setCursor(Qt.CursorShape.OpenHandCursor)
 
         QScroller.grabGesture(self.viewport(), QScroller.ScrollerGestureType.LeftMouseButtonGesture)
         scroller = QScroller.scroller(self.viewport())
@@ -1328,17 +1392,16 @@ class SettingInterface(ScrollArea):
             "ui_language",
             FIF.LANGUAGE,
             '界面语言 / 界面語言 / 인터페이스 언어 / UI Language',
-            '切换后即时生效 / 切換後即時生效 / 변경 즉시 적용 / Takes effect immediately',
+            '需要重启程序生效 / 需要重啟程式生效 / 변경 사항을 적용하려면 재시작 필요 / Requires restart to take effect',
             texts={'自动': 'auto', '简体中文': 'zh_CN', '繁體中文': 'zh_TW', '한국어': 'ko_KR', 'English': 'en_US'}
         )
 
     def __initLayout(self):
         self.settingLabel.move(36, 30)
-        # pivot 放置在 pivotScrollArea 内，后者覆盖选项卡区域
-        # x=40 与 settingLabel 对齐，y=80 与原 pivot 位置一致
-        # 宽度 = 窗口宽 - 40，由 resizeEvent 保持同步
+        # pivot 现在位于 pivotScrollArea 内，直接定位 scroll area 即可
+        # y=80, height=60 → 底边 y=140，与 setViewportMargins(0, 140, ...) 对齐
         self.pivotScrollArea.move(40, 80)
-        self.pivotScrollArea.setFixedHeight(50)
+        self.pivotScrollArea.setFixedHeight(60)
         self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 200))
         # self.title_area.move(36, 80)
         # self.vBoxLayout.addWidget(self.pivot, 0, Qt.AlignTop)
@@ -1596,10 +1659,6 @@ class SettingInterface(ScrollArea):
         self.stackedWidget.currentChanged.connect(self.onCurrentIndexChanged)
         self.pivot.setCurrentItem(self.stackedWidget.currentWidget().objectName())
         self.stackedWidget.setFixedHeight(self.stackedWidget.currentWidget().sizeHint().height())
-
-    def resizeEvent(self, event):
-        super().resizeEvent(event)
-        self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 200))
 
     def __connectSignalToSlot(self):
         # self.importConfigCard.clicked.connect(self.__onImportConfigCardClicked)

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -23,49 +23,73 @@ import os
 import sys
 
 
-class _PivotDragFilter(QObject):
-    """为 pivot 滚动区域的 viewport 提供鼠标拖拽横向滚动。
+class _PivotScrollFilter(QObject):
+    """为 pivot 及其所有子控件（tab 按钮）提供横向滚动支持。
 
-    设计原则：
-    - 按下时记录起点，不消费事件（pivot tab 的 hover/press 状态正常触发）
-    - 移动超过阈值后进入拖拽模式，消费 Move 事件防止 pivot hover 抖动
-    - 释放时：拖拽模式下消费事件（防止误触 tab 切换），点击模式下放行
+    安装方式（在所有 addItem 完成后）：
+        self.pivot.installEventFilter(filter)
+        for child in self.pivot.findChildren(QWidget):
+            child.installEventFilter(filter)
+
+    之所以安装在子控件而非 viewport：Qt 鼠标事件直接投递给目标 widget
+    （tab 按钮），不经过 QScrollArea.viewport()，viewport 上的 filter 无效。
+
+    行为：
+    - Wheel → 横向滚动，消费事件（防止冒泡到外层纵向 ScrollArea）
+    - Press  → 记录全局起点，放行（tab hover/press 正常触发）
+    - Move>阈值 → 拖拽模式，消费 Move，滚动 scrollbar，显示 ClosedHandCursor
+    - Release → 拖拽后消费（防误切 tab），点击放行
     """
-    _THRESHOLD = 6  # px，低于此距离视为点击
+    _DRAG_THRESHOLD = 5  # px；低于此值视为点击
 
     def __init__(self, scroll_area: QScrollArea):
         super().__init__(scroll_area)
         self._sa = scroll_area
-        self._press_pos: QPoint | None = None
-        self._scroll_origin: int = 0
-        self._dragging: bool = False
+        self._press_global: QPoint | None = None
+        self._drag_origin: int = 0
+        self._is_dragging: bool = False
 
     def eventFilter(self, obj, event: QEvent) -> bool:
         t = event.type()
-        if t == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
-            self._press_pos = event.position().toPoint()
-            self._scroll_origin = self._sa.horizontalScrollBar().value()
-            self._dragging = False
-            return False  # 放行，pivot 正常接收 press
 
-        if t == QEvent.Type.MouseMove and (event.buttons() & Qt.MouseButton.LeftButton):
-            if self._press_pos is not None:
-                dx = event.position().toPoint().x() - self._press_pos.x()
-                if not self._dragging and abs(dx) > self._THRESHOLD:
-                    self._dragging = True
-                    # 覆盖光标提示用户正在拖拽
-                    self._sa.viewport().setCursor(Qt.CursorShape.ClosedHandCursor)
-                if self._dragging:
-                    self._sa.horizontalScrollBar().setValue(self._scroll_origin - dx)
-                    return True  # 拖拽期间消费，避免 pivot hover 闪烁
+        # ── 滚轮 → 横向滚动（消费，不冒泡给外层纵向 ScrollArea）───────
+        if t == QEvent.Type.Wheel:
+            delta = event.angleDelta()
+            # 触控板可能有原生水平 delta，优先使用；否则用垂直 delta 映射
+            scroll = delta.x() if delta.x() != 0 else delta.y()
+            sb = self._sa.horizontalScrollBar()
+            sb.setValue(sb.value() - scroll // 3)
+            return True
+
+        # ── 按下 → 记录全局起点，不消费（tab 正常收到 press）────────────
+        if t == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
+            self._press_global = event.globalPosition().toPoint()
+            self._drag_origin = self._sa.horizontalScrollBar().value()
+            self._is_dragging = False
             return False
 
+        # ── 移动 → 超阈值进入拖拽，消费 Move ────────────────────────────
+        if t == QEvent.Type.MouseMove and (event.buttons() & Qt.MouseButton.LeftButton):
+            if self._press_global is not None:
+                dx = event.globalPosition().toPoint().x() - self._press_global.x()
+                if not self._is_dragging and abs(dx) > self._DRAG_THRESHOLD:
+                    self._is_dragging = True
+                    QApplication.setOverrideCursor(Qt.CursorShape.ClosedHandCursor)
+                if self._is_dragging:
+                    self._sa.horizontalScrollBar().setValue(self._drag_origin - dx)
+                    return True  # 消费：避免 tab hover 闪动
+            return False
+
+        # ── 释放 → 拖拽后消费（防误切 tab），点击放行 ────────────────────
         if t == QEvent.Type.MouseButtonRelease and event.button() == Qt.MouseButton.LeftButton:
-            was_dragging = self._dragging
-            self._press_pos = None
-            self._dragging = False
-            self._sa.viewport().unsetCursor()
-            return was_dragging  # 拖拽后消费 release，防止误切 tab
+            if self._press_global is not None:
+                was_dragging = self._is_dragging
+                self._press_global = None
+                self._is_dragging = False
+                if was_dragging:
+                    QApplication.restoreOverrideCursor()
+                    return True  # 消费：拖拽结束不触发 tab 切换
+            return False
 
         return False
 
@@ -100,44 +124,42 @@ class SettingInterface(ScrollArea):
         StyleSheet.SETTING_INTERFACE.apply(self)
 
         # ── 选项卡滚动容器 ──────────────────────────────────────────────
-        # 当标签文字较长（如英语）时允许横向滚动；拖拽由 _PivotDragFilter 处理。
-        # QScroller.LeftMouseButtonGesture 不用于此处：它会在 drag 检测期间拦截
-        # 所有鼠标事件，导致 pivot tab 点击无法触发。
+        # 当标签文字较长（如英语）时允许横向滚动。
+        # 注意：不在此处安装 _PivotScrollFilter，因为 pivot 的 tab 子控件
+        # 尚未创建（addItem 在 __initLayout 中调用）。filter 在 __initLayout
+        # 最后通过 pivot.findChildren(QWidget) 递归安装，覆盖所有 tab 子控件。
         self.pivotScrollArea = QScrollArea(self)
         self.pivotScrollArea.setWidget(self.pivot)
         self.pivotScrollArea.setWidgetResizable(False)
-        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
+        # AsNeeded：中文下不显示（清洁），英文下溢出时自动出现
+        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.pivotScrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.pivotScrollArea.setFrameShape(QFrame.Shape.NoFrame)
-        # 滚动条：10px 高，轨道有底色便于识别，handle 高对比，hover/press 加深
+        # 滚动条：8px 药丸形，轨道有底色便于发现，hover/press 加深
         self.pivotScrollArea.horizontalScrollBar().setStyleSheet("""
             QScrollBar:horizontal {
-                height: 10px;
-                background: rgba(128, 128, 128, 0.18);
-                border-radius: 5px;
+                height: 8px;
+                background: rgba(128, 128, 128, 0.15);
+                border-radius: 4px;
                 margin: 0px;
             }
             QScrollBar::handle:horizontal {
-                background: rgba(90, 90, 90, 0.65);
-                border-radius: 5px;
-                min-width: 40px;
+                background: rgba(100, 100, 100, 0.55);
+                border-radius: 4px;
+                min-width: 36px;
             }
             QScrollBar::handle:horizontal:hover {
-                background: rgba(60, 60, 60, 0.85);
+                background: rgba(70, 70, 70, 0.80);
             }
             QScrollBar::handle:horizontal:pressed {
-                background: rgba(30, 30, 30, 0.98);
+                background: rgba(40, 40, 40, 0.96);
             }
             QScrollBar::add-line:horizontal,
             QScrollBar::sub-line:horizontal {
                 width: 0px;
+                background: none;
             }
         """)
-        # 鼠标拖拽横向滚动（区分拖拽 vs 点击，不干扰 tab 切换）
-        self._pivot_drag_filter = _PivotDragFilter(self.pivotScrollArea)
-        self.pivotScrollArea.viewport().installEventFilter(self._pivot_drag_filter)
-        # 鼠标悬停时显示手型光标，提示可拖拽
-        self.pivotScrollArea.viewport().setCursor(Qt.CursorShape.OpenHandCursor)
 
         QScroller.grabGesture(self.viewport(), QScroller.ScrollerGestureType.LeftMouseButtonGesture)
         scroller = QScroller.scroller(self.viewport())
@@ -1392,17 +1414,27 @@ class SettingInterface(ScrollArea):
             "ui_language",
             FIF.LANGUAGE,
             '界面语言 / 界面語言 / 인터페이스 언어 / UI Language',
-            '需要重启程序生效 / 需要重啟程式生效 / 변경 사항을 적용하려면 재시작 필요 / Requires restart to take effect',
+            '切换后即时生效 / 切換後即時生效 / 변경 즉시 적용 / Takes effect immediately',
             texts={'自动': 'auto', '简体中文': 'zh_CN', '繁體中文': 'zh_TW', '한국어': 'ko_KR', 'English': 'en_US'}
         )
 
     def __initLayout(self):
         self.settingLabel.move(36, 30)
-        # pivot 现在位于 pivotScrollArea 内，直接定位 scroll area 即可
-        # y=80, height=60 → 底边 y=140，与 setViewportMargins(0, 140, ...) 对齐
+        # pivot 位于 pivotScrollArea 内；x=40 与标题对齐，y=80 与原位置一致
+        # height=54：pivot ~46px + 8px 供 AsNeeded 滚动条偶尔占用，底边 y=134
+        # setViewportMargins(0, 140, ...) 保留 6px 间距，不影响内容区域
         self.pivotScrollArea.move(40, 80)
-        self.pivotScrollArea.setFixedHeight(60)
-        self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 200))
+        self.pivotScrollArea.setFixedHeight(54)
+        # ── 关键修复：构造时必须给 scroll area 设置初始宽度 ──────────────
+        # self.width() 在 __init__ 期间为 0（QWidget 尚未布局），
+        # 但 self.parent 是已显示的 MainWindow，其宽度有效（≥960）。
+        # 若无法取到父宽度则回退到最小窗口宽度 960。
+        # resizeEvent 会在窗口缩放时持续更新该值。
+        try:
+            initial_w = self.parent.width() if self.parent and self.parent.width() > 0 else 960
+        except Exception:
+            initial_w = 960
+        self.pivotScrollArea.setFixedWidth(max(initial_w - 40, 400))
         # self.title_area.move(36, 80)
         # self.vBoxLayout.addWidget(self.pivot, 0, Qt.AlignTop)
         self.vBoxLayout.addWidget(self.stackedWidget, 0, Qt.AlignmentFlag.AlignTop)
@@ -1659,6 +1691,22 @@ class SettingInterface(ScrollArea):
         self.stackedWidget.currentChanged.connect(self.onCurrentIndexChanged)
         self.pivot.setCurrentItem(self.stackedWidget.currentWidget().objectName())
         self.stackedWidget.setFixedHeight(self.stackedWidget.currentWidget().sizeHint().height())
+
+        # ── pivot 尺寸与滚动过滤器 ────────────────────────────────────
+        # 所有 addItem 调用完成后 pivot 才能计算正确宽度
+        self.pivot.adjustSize()
+        # 将滚动/拖拽过滤器安装到 pivot 本身及其所有子控件（tab 按钮）
+        # 只在 viewport 上安装不够：tab 子控件直接收到鼠标事件，不经过 viewport
+        self._pivot_scroll_filter = _PivotScrollFilter(self.pivotScrollArea)
+        self.pivot.installEventFilter(self._pivot_scroll_filter)
+        for child in self.pivot.findChildren(QWidget):
+            child.installEventFilter(self._pivot_scroll_filter)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        # 随窗口宽度同步 pivot 滚动容器宽度（right margin = 40px 与布局对齐）
+        if self.width() > 0:
+            self.pivotScrollArea.setFixedWidth(max(self.width() - 40, 400))
 
     def __connectSignalToSlot(self):
         # self.importConfigCard.clicked.connect(self.__onImportConfigCardClicked)

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -118,7 +118,32 @@ class SettingInterface(ScrollArea):
         self.setWidgetResizable(True)
         self.setViewportMargins(0, 140, 0, 5)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        
+        # self.title_area.setWidget(self.pivot)
+        # self.title_area.setWidgetResizable(True)
+        # self.title_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        # self.title_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        # self.title_area.setMinimumSize(800, 50)
+        # self.title_area.setStyleSheet("""
+        #     QScrollBar:horizontal {
+        #         height: 4px;
+        #         background: #f0f0f0;
+        #         border-radius: 10px;
+        #     }
 
+        #     QScrollBar::handle:horizontal {
+        #         background: #888;
+        #         border-radius: 10px;
+        #     }
+
+        #     QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+        #         background: none;
+        #     }
+
+        #     QScrollBar::handle:horizontal:hover {
+        #         background: #555;
+        #     }
+        # """)
         self.setObjectName('settingInterface')
         self.scrollWidget.setObjectName('scrollWidget')
         self.settingLabel.setObjectName('settingLabel')

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt, QUrl
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtWidgets import QWidget, QLabel, QFileDialog, QVBoxLayout, QStackedWidget, QSpacerItem, QScroller, QScrollerProperties
+from PySide6.QtWidgets import QWidget, QLabel, QFileDialog, QVBoxLayout, QStackedWidget, QSpacerItem, QScroller, QScrollerProperties, QScrollArea, QFrame
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import SettingCardGroup, PushSettingCard, ScrollArea, InfoBar, PrimaryPushSettingCard
 from app.sub_interfaces.accounts_interface import accounts_interface
@@ -47,35 +47,33 @@ class SettingInterface(ScrollArea):
         self.setViewportMargins(0, 140, 0, 5)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
-        # self.title_area.setWidget(self.pivot)
-        # self.title_area.setWidgetResizable(True)
-        # self.title_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
-        # self.title_area.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        # self.title_area.setMinimumSize(800, 50)
-        # self.title_area.setStyleSheet("""
-        #     QScrollBar:horizontal {
-        #         height: 4px;
-        #         background: #f0f0f0;
-        #         border-radius: 10px;
-        #     }
-
-        #     QScrollBar::handle:horizontal {
-        #         background: #888;
-        #         border-radius: 10px;
-        #     }
-
-        #     QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
-        #         background: none;
-        #     }
-
-        #     QScrollBar::handle:horizontal:hover {
-        #         background: #555;
-        #     }
-        # """)
         self.setObjectName('settingInterface')
         self.scrollWidget.setObjectName('scrollWidget')
         self.settingLabel.setObjectName('settingLabel')
         StyleSheet.SETTING_INTERFACE.apply(self)
+
+        # 选项卡滚动区域：当标签文字较长（如英语）时允许横向滚动
+        self.pivotScrollArea = QScrollArea(self)
+        self.pivotScrollArea.setWidget(self.pivot)
+        self.pivotScrollArea.setWidgetResizable(False)
+        self.pivotScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.pivotScrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.pivotScrollArea.setFrameShape(QFrame.Shape.NoFrame)
+        self.pivotScrollArea.setStyleSheet("""
+            QScrollBar:horizontal {
+                height: 3px;
+                background: transparent;
+            }
+            QScrollBar::handle:horizontal {
+                background: rgba(134, 134, 134, 0.45);
+                border-radius: 1px;
+                min-width: 24px;
+            }
+            QScrollBar::add-line:horizontal,
+            QScrollBar::sub-line:horizontal {
+                width: 0px;
+            }
+        """)
 
         QScroller.grabGesture(self.viewport(), QScroller.ScrollerGestureType.LeftMouseButtonGesture)
         scroller = QScroller.scroller(self.viewport())
@@ -1330,13 +1328,16 @@ class SettingInterface(ScrollArea):
             "ui_language",
             FIF.LANGUAGE,
             '界面语言 / 界面語言 / 인터페이스 언어 / UI Language',
-            '需要重启程序生效 / 需要重啟程式生效 / 변경 사항을 적용하려면 재시작 필요 / Requires restart to take effect',
+            '切换后即时生效 / 切換後即時生效 / 변경 즉시 적용 / Takes effect immediately',
             texts={'自动': 'auto', '简体中文': 'zh_CN', '繁體中文': 'zh_TW', '한국어': 'ko_KR', 'English': 'en_US'}
         )
 
     def __initLayout(self):
         self.settingLabel.move(36, 30)
-        self.pivot.move(40, 80)
+        # pivot 放置在 pivotScrollArea 内，后者覆盖选项卡区域
+        self.pivotScrollArea.move(0, 68)
+        self.pivotScrollArea.setFixedHeight(62)
+        self.pivotScrollArea.setFixedWidth(self.width())
         # self.title_area.move(36, 80)
         # self.vBoxLayout.addWidget(self.pivot, 0, Qt.AlignTop)
         self.vBoxLayout.addWidget(self.stackedWidget, 0, Qt.AlignmentFlag.AlignTop)
@@ -1593,6 +1594,10 @@ class SettingInterface(ScrollArea):
         self.stackedWidget.currentChanged.connect(self.onCurrentIndexChanged)
         self.pivot.setCurrentItem(self.stackedWidget.currentWidget().objectName())
         self.stackedWidget.setFixedHeight(self.stackedWidget.currentWidget().sizeHint().height())
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.pivotScrollArea.setFixedWidth(self.width())
 
     def __connectSignalToSlot(self):
         # self.importConfigCard.clicked.connect(self.__onImportConfigCardClicked)


### PR DESCRIPTION
## 问题
- 使用英语等长标签语言时，设置页顶部选项卡（``pivot``）超出窗口宽度后被截断，只有最大化才能完整显示。
- 切换界面语言后需重启程序才能生效，体验割裂。

## 新增功能
- 选项卡支持横向滚动
- 语言切换热重载
 
## 改动
- `app/setting_interface.py`：将 pivot 包裹在 QScrollArea 中，超出时显示 3px 横向滚动条；resizeEvent 保持宽度同步。
- `app/main_window.py`：``_on_ui_language_changed`` 实现热重载——依次调用 ``load_language()``、重装 ``FluentTranslator``、延迟 50ms 后重建全部子界面（日志界面除外，以保护运行中任务）。
- 移除滚动条（两轴均 ``ScrollBarAlwaysOff``），仅保留拖拽，界面更简洁。``pivotScrollArea`` 高度随之缩减至 ``46px``。

## 依旧存在的问题
- 切换语言有短暂无响应，但不影响使用
- 日志页语言切换无法同步