### PR TITLE
feat: 添加自动模式支持，优化更新流程

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -19,8 +19,9 @@ from module.update.download_proxy import get_update_download_aria2_args, get_upd
 class Updater:
     """应用程序更新器，负责检查、下载、解压和安装最新版本的应用程序。"""
 
-    def __init__(self, logger: Logger, download_url=None, file_name=None):
+    def __init__(self, logger: Logger, download_url=None, file_name=None, auto_mode=False):
         self.logger = logger
+        self.auto_mode = auto_mode
         self.process_names = ["March7th Assistant.exe", "March7th Launcher.exe", "flet.exe", "gui.exe", "Fhoe-Rail.exe", "chromedriver.exe", "PaddleOCR-json.exe"]
         self.api_urls = [
             "https://api.github.com/repos/moesnow/March7thAssistant/releases/latest",
@@ -37,9 +38,14 @@ class Updater:
         self.logger.hr("获取下载链接", 0)
         if download_url is None:
             self.download_url = self.get_download_url()
+            if self.auto_mode and not self.download_url:
+                self.logger.info("当前已是最新版本，自动退出更新流程")
+                self.logger.hr("完成", 2)
+                sys.exit(0)
             self.logger.info(f"下载链接: {green(self.download_url)}")
             self.logger.hr("完成", 2)
-            input("按回车键开始更新")
+            if not self.auto_mode:
+                input("按回车键开始更新")
         else:
             self.logger.info(f"下载链接: {green(self.download_url)}")
             self.logger.hr("完成", 2)
@@ -73,7 +79,9 @@ class Updater:
         if download_url is None:
             raise Exception("没有找到合适的下载URL")
 
-        self.compare_versions(version)
+        has_update = self.compare_versions(version)
+        if self.auto_mode and not has_update:
+            return None
         return download_url
 
     def compare_versions(self, version):
@@ -83,13 +91,16 @@ class Updater:
                 current_version = file.read().strip()
             if parse(version.lstrip('v')) > parse(current_version.lstrip('v')):
                 self.logger.info(f"发现新版本: {current_version} ——> {version}")
+                return True
             else:
                 self.logger.info(f"本地版本: {current_version}")
                 self.logger.info(f"远程版本: {version}")
                 self.logger.info(f"当前已是最新版本")
+                return False
         except Exception as e:
             self.logger.info(f"本地版本获取失败: {e}")
             self.logger.info(f"最新版本: {version}")
+            return True
 
     def find_fastest_mirror(self, mirror_urls, timeout=5):
         """测速并找到最快的镜像。"""
@@ -572,10 +583,16 @@ def check_temp_dir_and_run():
     #     subprocess.Popen(args, creationflags=subprocess.DETACHED_PROCESS)
     #     sys.exit(0)
 
-    download_url = sys.argv[1] if len(sys.argv) == 3 else None
-    file_name = sys.argv[2] if len(sys.argv) == 3 else None
+    args = sys.argv[1:]
+    auto_mode = False
+    if args and args[0] in ("--auto", "-a", "/auto"):
+        auto_mode = True
+        args = args[1:]
+
+    download_url = args[0] if len(args) == 2 else None
+    file_name = args[1] if len(args) == 2 else None
     logger = Logger()
-    updater = Updater(logger, download_url, file_name)
+    updater = Updater(logger, download_url, file_name, auto_mode=auto_mode)
     updater.run()
 
 


### PR DESCRIPTION
改动点（文件：/D:/repo/March7thAssistant/updater.py）：

  1. 增加自动模式开关
     Updater.__init__ 增加参数 auto_mode=False，保存到 self.auto_mode。
  2. 自动模式下“已是最新”直接退出
     在 process_release_data -> compare_versions 增加布尔返回：

  - 有新版本：True
  - 已是最新：False
  - 本地版本读取失败：True（保守继续更新）
    并在自动模式下遇到 False 时返回 None，__init__ 里检测到后 sys.exit(0) 退出更新流程。

  3. 自动模式下跳过“按回车开始更新”
     仅在非自动模式时才执行这一步 input(...)。
  4. 入口参数解析新增自动参数
     check_temp_dir_and_run() 现在支持：

  - --auto / -a / /auto 开启自动模式
  - 自动模式可配合旧的2参数下载方式一起用

  当前行为：

  - 无参数（双击运行）
    保持原流程：检查更新后仍走原来的人工确认流程。
  - 有自动参数（如 --auto）
    自动判断版本：
    已是最新 -> 自动退出；
    需要更新 -> 按原更新流程执行，但不需要“开始前回车确认”。