### PR TITLE
fix: 修复差分宇宙周期积分OCR识别坐标错误

### DIFF
--- a/tasks/weekly/divergent_universe.py
+++ b/tasks/weekly/divergent_universe.py
@@ -54,7 +54,7 @@ class DivergentUniverse:
             cfg.save_timestamp("weekly_divergent_timestamp")
             return True
 
-        score_pos = (182 / 1920, 977 / 1080, 209 / 1920, 43 / 1080)
+        score_pos = (443 / 1920, 872 / 1080, 221 / 1920, 51 / 1080)
         score = auto.get_single_line_text(score_pos)
         if not score:
             log.warning("未识别到差分宇宙积分")


### PR DESCRIPTION
## 问题描述

4.2版本后周期积分显示位置发生变更，原坐标 `(182/1920, 977/1080)` 无法正确识别周期积分数字，导致差分宇宙任务运行时无法正确检查积分完成情况。

## 修复内容

更新 OCR 识别坐标为 `(443/1920, 872/1080, 221/1920, 51/1080)`，经测试验证可正确识别周期积分。

## 文件变更

- `tasks/weekly/divergent_universe.py`: 更新 `score_pos` 坐标

## 测试

已在本地测试验证新坐标可正确 OCR 识别周期积分数字（如 `100/800`）。