### PR TITLE
fix: 修复外部程序启动失败的问题，恢复 BetterGI 定时任务支持

### DIFF
--- a/app/log_interface.py
+++ b/app/log_interface.py
@@ -875,9 +875,19 @@ class LogInterface(ScrollArea):
             self.appendLog(f"========== 开始任务: {name} ==========\n")
 
             proc = QProcess(self)
-            proc.setProcessChannelMode(QProcess.MergedChannels)
-            proc.readyReadStandardOutput.connect(self._onReadyRead)
-            proc.readyReadStandardError.connect(self._onReadyRead)
+            # BetterGI（.NET 应用）启动时会调用 AllocateConsole 并将继承的标准
+            # 句柄包装为同步 FileStream，与 QProcess 创建的 overlapped I/O 管道
+            # 不兼容，导致 "Handle does not support synchronous operations" 错误。
+            # 仅对 BetterGI 将标准流重定向到 NUL 以避免创建管道。
+            if os.path.basename(program).lower() == 'bettergi.exe':
+                null = QProcess.nullDevice()
+                proc.setStandardInputFile(null)
+                proc.setStandardOutputFile(null)
+                proc.setStandardErrorFile(null)
+            else:
+                proc.setProcessChannelMode(QProcess.MergedChannels)
+                proc.readyReadStandardOutput.connect(self._onReadyRead)
+                proc.readyReadStandardError.connect(self._onReadyRead)
             proc.finished.connect(self._onProcessFinished)
             proc.errorOccurred.connect(self._onProcessError)
 

--- a/assets/config/special_programs.jsonc
+++ b/assets/config/special_programs.jsonc
@@ -1,15 +1,15 @@
 {
     "special_programs": [
-        // {
-        //     "key": "bettergi",
-        //     "display_name": "原神 BetterGI",
-        //     "short_name": "原神",
-        //     "executable": "BetterGI.exe",
-        //     "default_args": "startOneDragon",
-        //     "kill_processes": [
-        //         "YuanShen.exe"
-        //     ]
-        // },
+        {
+            "key": "bettergi",
+            "display_name": "原神 BetterGI",
+            "short_name": "原神",
+            "executable": "BetterGI.exe",
+            "default_args": "startOneDragon",
+            "kill_processes": [
+                "YuanShen.exe"
+            ]
+        },
         {
             "key": "zzz_onedragon",
             "display_name": "绝区零 一条龙",


### PR DESCRIPTION
BetterGI（.NET 应用）启动时调用 AllocateConsole 并将继承的标准句柄包装为 同步 FileStream，与 QProcess 创建的 overlapped I/O 管道不兼容，导致 "Handle does not support synchronous operations" 错误。 仅对 BetterGI.exe 将标准流重定向到 NUL 以避免创建管道，其余外部程序保留原有日志捕获行为。

Fix #853 