### PR TITLE
fix(ci): 将 docker metadata 配置的内联注释改为独立行

### DIFF
--- a/.github/workflows/6.build_docker_image.yml
+++ b/.github/workflows/6.build_docker_image.yml
@@ -53,10 +53,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch                    # 分支推送时使用分支名作为标签（如 main）
-            type=sha,prefix={{branch}}-,enable=${{ github.ref_type != 'tag' }}  # 非标签推送时生成分支名-commit SHA 标签（如 main-abc1234）
-            type=ref,event=tag                       # 标签推送时保留完整标签名（如 v1.0.0）
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref, '-') }}  # 仅在推送稳定版标签时添加 latest 标签（不包含 -beta、-rc 等预发布版本）
+            # 分支推送时使用分支名作为标签（如 main）
+            type=ref,event=branch
+            # 非标签推送时生成分支名-commit SHA 标签（如 main-abc1234）
+            type=sha,prefix={{branch}}-,enable=${{ github.ref_type != 'tag' }}
+            # 标签推送时保留完整标签名（如 v1.0.0）
+            type=ref,event=tag
+            # 仅在推送稳定版标签时添加 latest 标签（不包含 -beta、-rc 等预发布版本）
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref, '-') }}
           flavor: |
             latest=false
 


### PR DESCRIPTION
docker/metadata-action@v6 不再接受内联注释，导致
"Invalid event" 解析错误。将注释移到单独一行即可修复。