### PR TITLE
feat: 为企业微信应用通知新增自定义url支持

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -1274,6 +1274,7 @@ class SettingInterface(ScrollArea):
                     "corpsecret": {"title": tr("应用密钥")},
                     "agentid": {"title": tr("应用 AgentId")},
                     "touser": {"title": tr("接收用户"), "description": tr("可选参数，接收用户，@all 表示全员")},
+                    "base_url": {"title": tr("自定义 API 地址"), "description": tr("可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制")},
                 }
             },
             "gotify": {

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -583,6 +583,7 @@ notify_wechatworkapp_corpid: "" # 企业微信的企业ID。
 notify_wechatworkapp_corpsecret: "" # 企业微信应用的密钥。
 notify_wechatworkapp_agentid: "" # 企业微信应用的AgentId。
 notify_wechatworkapp_touser: "" # 可选参数，企业微信应用通知的目标用户，"@all" 表示发送给所有人。
+notify_wechatworkapp_base_url: "" # 可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制。
 
 # 企业微信机器人通知配置
 notify_wechatworkbot_enable: false # 是否启用企业微信机器人通知。true 开启，false 关闭。

--- a/assets/locales/en_US.json
+++ b/assets/locales/en_US.json
@@ -1023,6 +1023,7 @@
     "应用 AgentId": "App AgentId",
     "接收用户": "Recipients",
     "可选参数，接收用户，@all 表示全员": "Optional: recipient users, @all means everyone",
+    "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制": "Optional: custom WeCom API URL for reverse proxy to bypass trusted IP restrictions",
     "Gotify 私有通知服务": "Gotify self-hosted notification service",
     "Gotify 服务器 URL，例如 https://gotify.example.com": "Gotify server URL, e.g. https://gotify.example.com",
     "Gotify 应用的 Access Token": "Gotify app access token",

--- a/assets/locales/ja_JP.json
+++ b/assets/locales/ja_JP.json
@@ -1023,6 +1023,7 @@
     "应用 AgentId": "App AgentId",
     "接收用户": "Recipients",
     "可选参数，接收用户，@all 表示全员": "Optional: recipient users, @all means everyone",
+    "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制": "オプション: リバースプロキシで信頼済み IP 制限を回避するためのカスタム WeCom API URL",
     "Gotify 私有通知服务": "Gotify self-hosted notification service",
     "Gotify 服务器 URL，例如 https://gotify.example.com": "Gotify server URL, e.g. https://gotify.example.com",
     "Gotify 应用的 Access Token": "Gotify app access token",

--- a/assets/locales/ko_KR.json
+++ b/assets/locales/ko_KR.json
@@ -1023,6 +1023,7 @@
     "应用 AgentId": "앱 AgentId",
     "接收用户": "수신 사용자",
     "可选参数，接收用户，@all 表示全员": "선택 사항: 수신 사용자 (@all 은 전체 대상)",
+    "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制": "선택 사항: 리버스 프록시를 통해 신뢰할 수 있는 IP 제한을 우회하기 위한 사용자 지정 WeCom API 주소",
     "Gotify 私有通知服务": "Gotify 자체 호스팅 알림 서비스",
     "Gotify 服务器 URL，例如 https://gotify.example.com": "Gotify 서버 URL (예: https://gotify.example.com)",
     "Gotify 应用的 Access Token": "Gotify 앱 Access Token",

--- a/assets/locales/zh_CN.json
+++ b/assets/locales/zh_CN.json
@@ -1023,6 +1023,7 @@
     "应用 AgentId": "应用 AgentId",
     "接收用户": "接收用户",
     "可选参数，接收用户，@all 表示全员": "可选参数，接收用户，@all 表示全员",
+    "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制": "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制",
     "Gotify 私有通知服务": "Gotify 私有通知服务",
     "Gotify 服务器 URL，例如 https://gotify.example.com": "Gotify 服务器 URL，例如 https://gotify.example.com",
     "Gotify 应用的 Access Token": "Gotify 应用的 Access Token",

--- a/assets/locales/zh_TW.json
+++ b/assets/locales/zh_TW.json
@@ -1023,6 +1023,7 @@
     "应用 AgentId": "應用 AgentId",
     "接收用户": "接收用戶",
     "可选参数，接收用户，@all 表示全员": "可選參數，接收用戶，@all 表示全員",
+    "可选参数，自定义企业微信 API 地址，用于反向代理绕过可信 IP 限制": "可選參數，自定義企業微信 API 地址，用於反向代理繞過可信 IP 限制",
     "Gotify 私有通知服务": "Gotify 私有通知服務",
     "Gotify 服务器 URL，例如 https://gotify.example.com": "Gotify 服務器 URL，例如 https://gotify.example.com",
     "Gotify 应用的 Access Token": "Gotify 應用的 Access Token",

--- a/module/notification/wechatworkapp.py
+++ b/module/notification/wechatworkapp.py
@@ -13,7 +13,7 @@ class WeChatworkappNotifier(Notifier):
 
         :return: 返回访问令牌字符串。
         """
-        access_token_api = f"https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid={self.corpid}&corpsecret={self.corpsecret}"
+        access_token_api = f"{self.base_url}/cgi-bin/gettoken?corpid={self.corpid}&corpsecret={self.corpsecret}"
         response = requests.get(access_token_api)
         response.raise_for_status()
         response = response.json()
@@ -31,7 +31,7 @@ class WeChatworkappNotifier(Notifier):
         :return: 返回上传文件的media_id。
         """
         headers = {"Content-Type": "multipart/form-data"}
-        upload_api = f"https://qyapi.weixin.qq.com/cgi-bin/media/upload?access_token={self.access_token}&type={type}"
+        upload_api = f"{self.base_url}/cgi-bin/media/upload?access_token={self.access_token}&type={type}"
         response = requests.post(upload_api, headers=headers, files={"media": upload_file})
         response.raise_for_status()
         response = response.json()
@@ -55,7 +55,7 @@ class WeChatworkappNotifier(Notifier):
             "image": {"media_id": media_id},
             "safe": 0,
         }
-        send_api = f"https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={self.access_token}"
+        send_api = f"{self.base_url}/cgi-bin/message/send?access_token={self.access_token}"
         response = requests.post(send_api, headers=headers, data=json.dumps(message))
         response.raise_for_status()
         response = response.json()
@@ -76,7 +76,7 @@ class WeChatworkappNotifier(Notifier):
             "text": {"content": text},
             "safe": 0,
         }
-        send_api = f"https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token={self.access_token}"
+        send_api = f"{self.base_url}/cgi-bin/message/send?access_token={self.access_token}"
         response = requests.post(send_api, headers=headers, data=json.dumps(message))
         response.raise_for_status()
         response = response.json()
@@ -95,6 +95,7 @@ class WeChatworkappNotifier(Notifier):
         self.corpsecret = self.params["corpsecret"]
         self.agentid = self.params["agentid"]
         self.touser = self.params["touser"]
+        self.base_url = self.params.get("base_url", "https://qyapi.weixin.qq.com").rstrip('/')
         self.access_token = self._get_access_token()
 
         # 构建消息文本

--- a/module/notification/wechatworkapp.py
+++ b/module/notification/wechatworkapp.py
@@ -95,7 +95,7 @@ class WeChatworkappNotifier(Notifier):
         self.corpsecret = self.params["corpsecret"]
         self.agentid = self.params["agentid"]
         self.touser = self.params["touser"]
-        self.base_url = self.params.get("base_url", "https://qyapi.weixin.qq.com").rstrip('/')
+        self.base_url = (self.params.get("base_url") or "https://qyapi.weixin.qq.com").rstrip('/')
         self.access_token = self._get_access_token()
 
         # 构建消息文本


### PR DESCRIPTION
企业微信应用有可信IP限制，只能通过预先配置的IP访问；
此PR为其新增了自定义URL的支持，可以用于反代API地址实现规避限制