### PR TITLE
fix: 修复主页卡片编辑器深色模式样式不生效

### DIFF
--- a/assets/app/qss/dark/card_edit_dialog.qss
+++ b/assets/app/qss/dark/card_edit_dialog.qss
@@ -11,7 +11,7 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="5"] {
+QFrame[frameShape="6"] {
     background-color: rgba(39, 39, 39, 0.96);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 6px;

--- a/assets/app/qss/light/card_edit_dialog.qss
+++ b/assets/app/qss/light/card_edit_dialog.qss
@@ -3,7 +3,7 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="5"] {
+QFrame[frameShape="6"] {
     background-color: rgba(255, 255, 255, 0.92);
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 6px;


### PR DESCRIPTION
## 修复内容

修复"编辑主页卡片"对话框在深色模式下卡片编辑器背景/边框样式不生效的问题（#1080）。

### 根因

`CardEditorWidget` 使用 `setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shadow.Raised)`，而 `QFrame.Shape.StyledPanel` 的枚举值为 **6**。

但 `assets/app/qss/{dark,light}/card_edit_dialog.qss` 中的属性选择器写的是 `QFrame[frameShape="5"]`（值为 5 的是 `VLine`），**匹配不到** `StyledPanel`（值为 6）的卡片编辑器，导致深色模式下该区域拿不到 `rgba(39,39,39,0.96)` 深色背景与边框，渲染异常。

### 修复方式

仅修改两处 qss 选择器：`QFrame[frameShape="5"]` → `QFrame[frameShape="6"]`（dark / light 各一行），不涉及任何 Python 代码。

### 验证

- 本地 offscreen 渲染断言：深色主题下卡片编辑器背景色为 `rgba(39,39,39,0.96)` 的合成色 (39,39,39) ✓
- VPS xvfb 实机渲染截图确认：深色模式卡片为深灰卡片、文字清晰、层级分明；浅色模式无回归 ✓
- `uv run pytest tests/ -v --tb=short`：590 passed, 1 skipped ✓

Related: #1080