### PR TITLE
fix: 修复主页卡片编辑器深色模式样式不生效

### DIFF
--- a/app/card/card_edit_dialog.py
+++ b/app/card/card_edit_dialog.py
@@ -343,6 +343,9 @@ class CardEditDialog(QDialog):
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.scroll_widget = QWidget()
+        # QScrollArea.setWidget 会强制 autoFillBackground，滚动内容默认用系统 palette
+        # 填充背景，深色模式下会露出浅灰底，需由 qss 按主题覆盖
+        self.scroll_widget.setObjectName("cardEditScrollWidget")
         self.cards_layout = QVBoxLayout(self.scroll_widget)
         self.cards_layout.setSpacing(8)
         scroll.setWidget(self.scroll_widget)

--- a/assets/app/qss/dark/card_edit_dialog.qss
+++ b/assets/app/qss/dark/card_edit_dialog.qss
@@ -11,7 +11,7 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="5"] {
+QFrame[frameShape="6"] {
     background-color: rgba(39, 39, 39, 0.96);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 6px;

--- a/assets/app/qss/dark/card_edit_dialog.qss
+++ b/assets/app/qss/dark/card_edit_dialog.qss
@@ -11,7 +11,11 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="6"] {
+#cardEditScrollWidget {
+    background-color: transparent;
+}
+
+CardEditorWidget {
     background-color: rgba(39, 39, 39, 0.96);
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 6px;

--- a/assets/app/qss/light/card_edit_dialog.qss
+++ b/assets/app/qss/light/card_edit_dialog.qss
@@ -3,7 +3,11 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="6"] {
+#cardEditScrollWidget {
+    background-color: transparent;
+}
+
+CardEditorWidget {
     background-color: rgba(255, 255, 255, 0.92);
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 6px;

--- a/assets/app/qss/light/card_edit_dialog.qss
+++ b/assets/app/qss/light/card_edit_dialog.qss
@@ -3,7 +3,7 @@ QScrollArea {
     border: none;
 }
 
-QFrame[frameShape="5"] {
+QFrame[frameShape="6"] {
     background-color: rgba(255, 255, 255, 0.92);
     border: 1px solid rgba(0, 0, 0, 0.08);
     border-radius: 6px;

--- a/tests/test_app/test_card_edit_dialog_style.py
+++ b/tests/test_app/test_card_edit_dialog_style.py
@@ -1,0 +1,72 @@
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32" or not hasattr(sys, 'getwindowsversion'),
+    reason="GUI 测试仅在 Windows 平台运行"
+)
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    try:
+        from PySide6.QtWidgets import QApplication
+        app = QApplication.instance()
+        if app is None:
+            app = QApplication(sys.argv)
+        return app
+    except ImportError:
+        pytest.skip("PySide6 未安装")
+
+
+def _sample(qapp, theme):
+    """渲染编辑主页卡片弹窗，取卡片、卡片间隙、弹窗空白处的像素
+
+    间隙露出的是滚动内容的背景：QScrollArea.setWidget 会强制
+    autoFillBackground，若 qss 没有按主题覆盖，深色模式下这里会是
+    系统 palette 的浅灰，卡片也会因半透明叠加而偏色。
+    """
+    from PySide6.QtCore import QPoint
+    from qfluentwidgets import setTheme
+    from app.card.card_edit_dialog import CardEditDialog, DEFAULT_CARDS
+
+    setTheme(theme)
+    dialog = CardEditDialog(DEFAULT_CARDS)
+    dialog.resize(750, 600)
+    dialog.show()
+    qapp.processEvents()
+    try:
+        card = dialog.card_editors[0]
+        image = dialog.grab().toImage()
+
+        def px(point):
+            return image.pixelColor(point).getRgb()[:3]
+
+        return {
+            # x=3 落在卡片 10px 内边距内，避开图标与按钮
+            "card": px(card.mapTo(dialog, QPoint(3, card.height() // 2))),
+            # 两张卡片之间的 8px 间隙
+            "gap": px(card.mapTo(dialog, QPoint(card.width() // 2, card.height() + 4))),
+            # 滚动区之外的弹窗空白处
+            "dialog": px(QPoint(dialog.width() - 8, 8)),
+        }
+    finally:
+        dialog.close()
+
+
+class TestCardEditDialogStyle:
+    def test_dark_mode(self, qapp):
+        """深色模式：卡片拿到 rgba(39,39,39,0.96) 叠加后的深色底，
+        间隙与弹窗同色（不残留系统 palette 的浅灰）"""
+        from qfluentwidgets import Theme
+        p = _sample(qapp, Theme.DARK)
+        assert p["card"] == (39, 39, 39)
+        assert p["gap"] == p["dialog"] == (43, 43, 43)
+
+    def test_light_mode(self, qapp):
+        """浅色模式无回归。弹窗底色来自系统 palette，故只做相对断言"""
+        from qfluentwidgets import Theme
+        p = _sample(qapp, Theme.LIGHT)
+        assert p["gap"] == p["dialog"]
+        assert p["card"] != p["gap"], "卡片应能与容器区分开"


### PR DESCRIPTION
## 修复内容

修复「编辑主页卡片」对话框在深色模式下的两处样式失效（#1080）。

### 根因一：qss 选择器匹配不到卡片编辑器

`CardEditorWidget` 使用 `setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shadow.Raised)`，而 `QFrame.Shape.StyledPanel` 的枚举值为 **6**；qss 中写的是 `QFrame[frameShape="5"]`（值 5 是 `VLine`），匹配不到卡片编辑器，导致深色模式下该区域拿不到深色背景与边框。

但把 `"5"` 直接改成 `"6"` 会引入新问题：Qt 的类型选择器 `QFrame` 会匹配 **QFrame 及其所有子类**。对话框自己的 `QScrollArea` 继承自 `QFrame`、默认 frameShape 同样是 `StyledPanel`，而 `QFrame[frameShape="6"]`（类型 + 属性）的优先级高于上方的 `QScrollArea` 规则，于是滚动容器会多出一圈卡片边框（离屏实测边缘像素：深色 (58,58,58)、浅色 (227,227,227)，均不等于对话框底色）。这正是 Copilot 在 review 中指出的问题。

因此改为按类名精确匹配 `CardEditorWidget`，与仓库既有写法一致（`assets/app/qss/dark/link_card.qss` 中的 `LinkCard { }` 对应 `app/components/link_card.py` 的 `class LinkCard(QFrame)`）。命中范围精确到卡片编辑器本身，不再连带任何 QFrame 子类。

> 补充：不能改用 `.QFrame[frameShape="6"]`（带点的类选择器）。它只匹配 `QFrame` 本身、不匹配子类，会把 `CardEditorWidget` 一起排除，等于让修复失效。

### 根因二：滚动内容的背景没有按主题覆盖

`QScrollArea.setWidget()` 会强制被设置的 widget `setAutoFillBackground(True)`，滚动内容因此用系统 palette 填充背景；而 `setTheme(Theme.DARK)` 并不会改动 `QApplication.palette()`（实测切换到深色主题后 `palette().window()` 仍为 (239,239,239)）。

结果是深色模式下滚动区域内部为一片浅灰底，卡片因半透明叠加也偏色（(47,47,47) 而非 (39,39,39)）；qss 中既有的 `QScrollArea { background-color: transparent; }` 因被滚动内容完全遮住，从未在可见区域生效。这对应 #1080 描述的「背景未未变深色」。

修法沿用仓库既有约定（`assets/app/qss/dark/icon_interface.qss` 的 `#scrollWidget` 规则）：给滚动内容设置 objectName，由 qss 按主题覆盖其背景。objectName 取 `cardEditScrollWidget` 而非通用的 `scrollWidget`，以避开 qfluentwidgets 与本仓库其它界面中同名控件被样式级联误伤的可能。

## 改动清单

| 文件 | 改动 |
| --- | --- |
| `app/card/card_edit_dialog.py` | 给 `scroll_widget` 设置 `objectName("cardEditScrollWidget")` |
| `assets/app/qss/dark/card_edit_dialog.qss` | 选择器 `QFrame[frameShape="6"]` → `CardEditorWidget`；新增 `#cardEditScrollWidget` 背景规则 |
| `assets/app/qss/light/card_edit_dialog.qss` | 同上 |
| `tests/test_app/test_card_edit_dialog_style.py` | 新增 2 例渲染断言 |

## 验证

离屏渲染（`QT_QPA_PLATFORM=offscreen`）采样对话框像素，深色模式：

| | 卡片 | 卡片间隙 | 对话框底色 | 滚动区边缘 |
| --- | --- | --- | --- | --- |
| 修复前 | (47, 47, 47) | (239, 239, 239) | (43, 43, 43) | (58, 58, 58) |
| 修复后 | (39, 39, 39) | (43, 43, 43) | (43, 43, 43) | (43, 43, 43) |

- 深色模式：卡片为 `rgba(39,39,39,0.96)` 的合成色 (39,39,39)，卡片间隙与对话框底色一致，滚动容器不再有多余边框
- 浅色模式无回归（弹窗底色来自系统 palette，故测试对浅色只做相对断言）
- 新增测试的有效性已验证：将 qss 退回本 PR 之前的版本后，深色用例立即失败（`assert (47, 47, 47) == (39, 39, 39)`）
- `uv run pytest tests/`：592 passed, 1 skipped

## 范围说明

本 PR 只处理「编辑主页卡片」弹窗。#1080 中「流程编排」弹窗的部分不在本 PR 范围内，故不关闭该 issue。

Related: #1080
