### PR TITLE
fix：定时任务非零退出码时, 仍提示完成

### DIFF
--- a/app/log_interface.py
+++ b/app/log_interface.py
@@ -1682,7 +1682,7 @@ class LogInterface(ScrollArea):
             self._user_initiated_stop = False
         except Exception:
             user_stop = False
-        if exit_status == QProcess.NormalExit:
+        if exit_status == QProcess.NormalExit and exit_code == 0:
             self.appendLog(f"任务完成，退出码: {exit_code}\n")
         else:
             if user_stop:
@@ -1771,9 +1771,15 @@ class LogInterface(ScrollArea):
                             # 用户停止不视为异常；否则根据退出状态与异常标记判定
                             abnormal = False
                             try:
-                                abnormal = (not user_stop) and (getattr(self, '_stopped_abnormally', False) or exit_status != QProcess.NormalExit)
+                                abnormal = (not user_stop) and (
+                                    getattr(self, '_stopped_abnormally', False)
+                                    or exit_status != QProcess.NormalExit
+                                    or exit_code != 0
+                                )
                             except Exception:
-                                abnormal = (not user_stop) and (exit_status != QProcess.NormalExit)
+                                abnormal = (not user_stop) and (
+                                    exit_status != QProcess.NormalExit or exit_code != 0
+                                )
                             note = (f"定时任务异常结束: {pm.get('name', '')}" if abnormal else f"定时任务完成: {pm.get('name', '')}")
 
                             def _send_notify(n):


### PR DESCRIPTION
## Background

定时任务子进程以非零退出码正常退出时（例如游戏切换超时导致 `sys.exit(1)`），`QProcess` 会报告 `NormalExit`。原逻辑只检查退出状态，仍将其记录并通知为“定时任务完成”。

如下图所示
<img width="710" height="496" alt="image" src="https://github.com/user-attachments/assets/db0c5ddd-5358-4825-9097-7b5d85d6a83c" />


## Fix

- 仅在 `NormalExit` 且退出码为 `0` 时记录任务完成。
- 定时任务通知将任何非零退出码视为异常；包括异常分支的回退判定。

这样超时等失败将通知为“定时任务异常结束”，而非“定时任务完成”。

## Tests

- `python3 -m compileall -q app/log_interface.py`
- `uvx --from pytest pytest -q tests/test_app/test_log_interface.py`