### PR TITLE
fix: 修复 OCR GPU(DML) 加速被误降级到 CPU 的问题

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -362,7 +362,9 @@ apocalyptic_timestamp: 0 # 上次运行末日幻影的时间戳，用于记录�
 auto_battle_detect_enable: true # 是否启用自动战斗和二倍速检测。true 开启，false 关闭。
 
 # OCR 加速配置
-ocr_gpu_acceleration: auto # OCR 加速模式，可选值：auto（自动）, gpu（GPU）, onnx_dml（ONNXRuntime + DirectML）, cpu（CPU）, openvino_cpu（OpenVINO CPU）, onnx_cpu（ONNXRuntime CPU）。若 DML 模式过慢会自动切换到 cpu。
+ocr_gpu_acceleration: auto # OCR 加速模式，可选值：auto（自动）, gpu（GPU）, onnx_dml（ONNXRuntime + DirectML）, cpu（CPU）, openvino_cpu（OpenVINO CPU）, onnx_cpu（ONNXRuntime CPU）。若 DML 连续多次过慢会自动降级到 onnx_cpu。
+ocr_slow_threshold: 5.0 # DML 模式下单次 OCR 耗时超过此值（秒）计为一次"慢"，仅在 ocr_gpu_acceleration 为 auto/gpu/onnx_dml 时生效；非法值回退默认，设为极大值可视为禁用自动降级。
+ocr_slow_consecutive_threshold: 3 # DML 连续"慢"达到此次数才降级到 onnx_cpu，避免首帧冷启动或偶发抖动误杀。设为 1 即单次超阈值立即降级；最小为 1，非法值回退默认。
 
 # 自动修改分辨率配置
 auto_set_resolution_enable: true # 是否启用自动修改分辨率功能。true 开启，false 关闭。

--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -7,13 +7,15 @@ import re
 import subprocess
 from utils.logger.logger import Logger
 from typing import Optional
-from PIL import Image
+from PIL import Image, ImageDraw
 import atexit
 import gc
 
 
-# OCR 耗时阈值（秒），超过此值时自动禁用 DML
+# OCR 耗时阈值（秒），超过此值时累计一次“慢”
 OCR_SLOW_THRESHOLD = 5.0
+# DML 连续多少次“慢”才降级到 ONNXRuntime(CPU)，避免首帧冷启动 / 偶发抖动误杀
+OCR_SLOW_CONSECUTIVE_THRESHOLD = 3
 # 固定图片压测表明，RapidOCR 在连续多次识别时会创建大量中间 ndarray、
 # RapidOCROutput、以及 to_json 生成的 Python 容器对象。它们并非真正泄漏，
 # 但往往要等到 full GC 才会集中回收，所以任务管理器里会表现为 RSS 快速
@@ -59,6 +61,9 @@ class OCR:
         self.ocr_count = 0
         self._periodic_gc_interval = OCR_PERIODIC_FULL_GC_INTERVAL
         self._openvino_last_reinit = 0.0  # 上次 OpenVINO 重初始化的时间戳
+        self._slow_count = 0  # DML 连续慢速计数，达到阈值才降级
+        self._slow_threshold = OCR_SLOW_THRESHOLD  # 单次慢速阈值（秒），可被配置覆盖
+        self._slow_consecutive = OCR_SLOW_CONSECUTIVE_THRESHOLD  # 连续慢速降级次数，可被配置覆盖
 
     def _maybe_collect_garbage(self):
         """在长时间 OCR 循环下定期触发 full GC，优先压低峰值内存。
@@ -208,7 +213,7 @@ class OCR:
                 self.logger.warning(f"保存配置失败：{e}")
 
     def _disable_gpu_acceleration(self):
-        """禁用 GPU 加速；仅在自动模式时写回 CPU 模式。"""
+        """禁用 GPU 加速；仅在自动模式时写回 ONNXRuntime(CPU) 模式。"""
         cfg = self._get_config()
         raw_mode = None
         if cfg is not None:
@@ -219,8 +224,10 @@ class OCR:
 
         should_persist = (raw_mode == OCR_MODE_AUTO) or (raw_mode is True)
         if should_persist:
-            self._set_mode(OCR_MODE_CPU)
-            self.logger.info("已自动切换 OCR 加速模式为 CPU")
+            # 持久化为 onnx_cpu 而不是 cpu：cpu 模式在有 OpenVINO 的环境下会被
+            # 再次解析成 OpenVINO，重新引入本次修复要避开的高 CPU 占用引擎。
+            self._set_mode(OCR_MODE_ONNX_CPU)
+            self.logger.info("已自动切换 OCR 加速模式为 ONNXRuntime(CPU)")
         else:
             self.logger.info("已降级到 CPU 模式")
 
@@ -496,6 +503,44 @@ class OCR:
 
         return True, ""
 
+    def _load_thresholds(self):
+        """从配置加载慢速阈值与连续降级次数，缺失或非法时回退到默认常量。"""
+        cfg = self._get_config()
+        if cfg is None:
+            return
+        try:
+            threshold = float(cfg.get_value("ocr_slow_threshold", OCR_SLOW_THRESHOLD))
+            # 过滤负数与 NaN（NaN 比较恒为 False，被条件自然排除）；
+            # 极大值合法，等效于关闭自动降级
+            self._slow_threshold = (
+                threshold if threshold > 0 else OCR_SLOW_THRESHOLD
+            )
+        except Exception:
+            self._slow_threshold = OCR_SLOW_THRESHOLD
+        try:
+            self._slow_consecutive = int(
+                cfg.get_value("ocr_slow_consecutive_threshold", OCR_SLOW_CONSECUTIVE_THRESHOLD)
+            )
+            if self._slow_consecutive < 1:
+                self._slow_consecutive = OCR_SLOW_CONSECUTIVE_THRESHOLD
+        except Exception:
+            self._slow_consecutive = OCR_SLOW_CONSECUTIVE_THRESHOLD
+
+    def _warmup_dml(self):
+        """DML 首帧推理需要编译 shader、上传权重，冷启动开销很大。
+
+        在初始化阶段做一次预热推理，把冷启动耗时消化在这里，避免首次
+        真实 OCR 因首帧过慢被慢速检测误判为“DML 过慢”而降级到 CPU。
+        高度 200 大于 Global.min_height(155)，确保 det 算子被触发；
+        白图检不出 det 框时 rec 分支不会执行，因此需画上文字让
+        det + rec 全链路完成编译。
+        """
+        warmup_img = Image.new("RGB", (320, 200), "white")
+        ImageDraw.Draw(warmup_img).text((40, 60), "Hello World 123", fill="black")
+        start = time.monotonic()
+        self.ocr(warmup_img)
+        self.logger.info(f"DML 预热完成，耗时 {time.monotonic() - start:.2f} 秒")
+
     def _resolve_engine(self, selected_mode, force_cpu=False, force_onnx=False):
         """根据配置模式和运行环境解析实际引擎与 DML 开关。"""
         from rapidocr import EngineType
@@ -585,6 +630,7 @@ class OCR:
                 start_time = time.monotonic()
                 from rapidocr import EngineType, LangDet, ModelType, OCRVersion, RapidOCR
                 self._selected_mode = self._get_selected_mode()
+                self._load_thresholds()
                 prefer_engine, use_dml, resolved_mode = self._resolve_engine(
                     self._selected_mode,
                     force_cpu=force_cpu,
@@ -653,6 +699,19 @@ class OCR:
                 self.logger.debug("初始化OCR完成")
                 elapsed_time = time.monotonic() - start_time
                 self.logger.debug(f"OCR初始化耗时: {elapsed_time:.2f} 秒")
+
+                # DML 预热：消化首帧 shader 编译开销，避免慢速检测误杀冷启动。
+                # 预热失败说明 DML 实际跑不起来，降级到 ONNXRuntime(CPU)；
+                # force_onnx 会使 _use_dml=False，重建时不会再触发预热，无递归。
+                if self._use_dml:
+                    try:
+                        self._warmup_dml()
+                    except Exception as we:
+                        self.logger.warning(f"DML 预热失败: {we}，降级到 ONNXRuntime(CPU)")
+                        self.ocr = None
+                        self.instance_ocr(force_onnx=True)
+                        return
+
                 if self._using_openvino:
                     self._openvino_last_reinit = time.monotonic()
                     # 初始化后立即检查可用内存，不足 1GB 则降级
@@ -664,6 +723,7 @@ class OCR:
 
     def exit_ocr(self):
         """退出OCR实例，清理资源"""
+        self._slow_count = 0  # 连续慢速计数以单次实例生命周期为界，重建后重新累计
         if self.ocr is not None:
             try:
                 self.ocr = None
@@ -720,15 +780,26 @@ class OCR:
                     self.ocr_time += elapsed_time
                     self.ocr_count += 1
 
-                    # 检测 DML 是否过慢，若超过阈值则自动降级
-                    if self._use_dml and not self._dml_fallback and elapsed_time > OCR_SLOW_THRESHOLD:
-                        self.logger.warning(f"OCR 执行耗时 {elapsed_time:.2f}s 超过阈值 {OCR_SLOW_THRESHOLD}s，正在降级到 CPU 模式...")
-                        self._disable_gpu_acceleration()
-                        self.exit_ocr()
-                        self.instance_ocr(force_cpu=True)
-                        # 用 CPU 模式重新执行一次
-                        original_dict = self.ocr(img).to_json()
-                        self.logger.info("已切换到 CPU 模式")
+                    # 检测 DML 是否过慢：连续多次超阈值才降级，
+                    # 避免首帧冷启动（已由 _warmup_dml 大幅缓解）或偶发抖动误杀。
+                    if self._use_dml and not self._dml_fallback and elapsed_time > self._slow_threshold:
+                        self._slow_count += 1
+                        self.logger.warning(
+                            f"OCR 执行耗时 {elapsed_time:.2f}s 超过阈值 {self._slow_threshold}s"
+                            f"（连续 {self._slow_count}/{self._slow_consecutive} 次）"
+                        )
+                        if self._slow_count >= self._slow_consecutive:
+                            self.logger.warning(f"DML 连续 {self._slow_consecutive} 次过慢，降级到 ONNXRuntime(CPU) 模式...")
+                            self._slow_count = 0
+                            self._disable_gpu_acceleration()
+                            self.exit_ocr()
+                            self.instance_ocr(force_onnx=True)
+                            # 用 ONNXRuntime(CPU) 模式重新执行一次
+                            original_dict = self.ocr(img).to_json()
+                            self.logger.info("已切换到 ONNXRuntime(CPU) 模式")
+                    elif self._slow_count > 0:
+                        # 稳态恢复正常，重置连续慢速计数
+                        self._slow_count = 0
 
                     results = self.replace_strings(original_dict)
                     # 成功路径最适合触发周期性回收：此时本轮 OCR 的业务处理已经完成，
@@ -748,20 +819,20 @@ class OCR:
                     # 其他 ONNXRuntimeError 直接降级到 CPU 模式，不重试
                     if "ONNXRuntimeError" in type(e).__name__ or "ONNXRuntimeError" in str(e):
                         if self._use_dml and not self._dml_fallback:
-                            self.logger.warning(f"OCR 执行出现 ONNX 错误: {e}，直接降级到 CPU 模式...")
+                            self.logger.warning(f"OCR 执行出现 ONNX 错误: {e}，直接降级到 ONNXRuntime(CPU) 模式...")
                             self._disable_gpu_acceleration()
                             self.exit_ocr()
-                            self.instance_ocr(force_cpu=True)
+                            self.instance_ocr(force_onnx=True)
                             try:
                                 original_dict = self.ocr(img).to_json()
-                                self.logger.info("CPU 模式执行成功")
+                                self.logger.info("ONNXRuntime(CPU) 模式执行成功")
                                 results = self.replace_strings(original_dict)
                                 # 降级到 CPU 后仍会走同样的输出构造流程，因此同样保留
                                 # 周期性 full GC 以控制长时间循环时的峰值内存。
                                 self._maybe_collect_garbage()
                                 return results
                             except Exception as cpu_e:
-                                self.logger.error(f"CPU 模式仍然失败: {cpu_e}")
+                                self.logger.error(f"ONNXRuntime(CPU) 模式仍然失败: {cpu_e}")
                                 raise
                     # OpenVINO 执行失败时降级到 ONNXRuntime
                     if self._using_openvino and not self._openvino_fallback:
@@ -781,17 +852,17 @@ class OCR:
 
             # 所有重试都失败，尝试关闭 DML 重新初始化
             if self._use_dml and not self._dml_fallback:
-                self.logger.warning("DML 模式多次失败，尝试降级到 CPU 模式...")
+                self.logger.warning("DML 模式多次失败，尝试降级到 ONNXRuntime(CPU) 模式...")
                 self._disable_gpu_acceleration()
                 self.exit_ocr()
-                self.instance_ocr(force_cpu=True)
+                self.instance_ocr(force_onnx=True)
                 try:
                     original_dict = self.ocr(img).to_json()
-                    self.logger.info("CPU 模式执行成功")
+                    self.logger.info("ONNXRuntime(CPU) 模式执行成功")
                     return self.replace_strings(original_dict)
                 except Exception as e:
                     if self._is_unicode_error(e):
-                        self.logger.error(f"CPU 模式仍然失败: {e}")
+                        self.logger.error(f"ONNXRuntime(CPU) 模式仍然失败: {e}")
                         return "{}"
                     raise
 

--- a/tests/test_module/test_ocr.py
+++ b/tests/test_module/test_ocr.py
@@ -1,4 +1,9 @@
-from module.ocr.ocr import OCR
+from module.ocr.ocr import (
+    OCR,
+    OCR_MODE_ONNX_CPU,
+    OCR_SLOW_CONSECUTIVE_THRESHOLD,
+    OCR_SLOW_THRESHOLD,
+)
 
 
 class TestOCRNormalizeMachine:
@@ -135,3 +140,166 @@ class TestDisableOpenVINOTelemetry:
                 OptInChecker._march7th_telemetry_disabled = original_flag
             elif hasattr(OptInChecker, "_march7th_telemetry_disabled"):
                 delattr(OptInChecker, "_march7th_telemetry_disabled")
+
+
+class _FakeConfig:
+    """最小配置桩：仅实现 OCR 用到的 get_value / set_value。"""
+
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def get_value(self, key, default=None):
+        return self.values.get(key, default)
+
+    def set_value(self, key, value):
+        self.values[key] = value
+
+
+def _create_ocr_for_internal_tests(config_values=None):
+    from unittest.mock import MagicMock
+    ocr = OCR.__new__(OCR)
+    ocr.logger = MagicMock()
+    ocr.replacements = None
+    ocr._cfg = _FakeConfig(config_values)
+    ocr._slow_threshold = OCR_SLOW_THRESHOLD
+    ocr._slow_consecutive = OCR_SLOW_CONSECUTIVE_THRESHOLD
+    ocr._slow_count = 0
+    return ocr
+
+
+class TestLoadThresholds:
+    def test_missing_config_keeps_defaults(self):
+        ocr = _create_ocr_for_internal_tests()
+        assert ocr._load_thresholds() is None
+        assert ocr._slow_threshold == OCR_SLOW_THRESHOLD
+        assert ocr._slow_consecutive == OCR_SLOW_CONSECUTIVE_THRESHOLD
+
+    def test_invalid_values_fall_back_to_defaults(self):
+        ocr = _create_ocr_for_internal_tests({
+            "ocr_slow_threshold": -1,
+            "ocr_slow_consecutive_threshold": 0,
+        })
+        ocr._load_thresholds()
+        assert ocr._slow_threshold == OCR_SLOW_THRESHOLD
+        assert ocr._slow_consecutive == OCR_SLOW_CONSECUTIVE_THRESHOLD
+
+        ocr = _create_ocr_for_internal_tests({
+            "ocr_slow_threshold": float("nan"),
+            "ocr_slow_consecutive_threshold": -5,
+        })
+        ocr._load_thresholds()
+        assert ocr._slow_threshold == OCR_SLOW_THRESHOLD
+        assert ocr._slow_consecutive == OCR_SLOW_CONSECUTIVE_THRESHOLD
+
+    def test_valid_values_applied(self):
+        ocr = _create_ocr_for_internal_tests({
+            "ocr_slow_threshold": 8.0,
+            "ocr_slow_consecutive_threshold": 2,
+        })
+        ocr._load_thresholds()
+        assert ocr._slow_threshold == 8.0
+        assert ocr._slow_consecutive == 2
+
+    def test_huge_threshold_keeps_degrade_disabled(self):
+        ocr = _create_ocr_for_internal_tests({"ocr_slow_threshold": float("inf")})
+        ocr._load_thresholds()
+        assert ocr._slow_threshold == float("inf")
+
+
+class TestDisableGpuAcceleration:
+    def test_auto_persists_onnx_cpu(self):
+        ocr = _create_ocr_for_internal_tests({"ocr_gpu_acceleration": "auto"})
+        ocr._disable_gpu_acceleration()
+        assert ocr._cfg.values["ocr_gpu_acceleration"] == OCR_MODE_ONNX_CPU
+
+    def test_legacy_bool_true_persists_onnx_cpu(self):
+        ocr = _create_ocr_for_internal_tests({"ocr_gpu_acceleration": True})
+        ocr._disable_gpu_acceleration()
+        assert ocr._cfg.values["ocr_gpu_acceleration"] == OCR_MODE_ONNX_CPU
+
+    def test_explicit_mode_not_overwritten(self):
+        for mode in ("gpu", "onnx_dml"):
+            ocr = _create_ocr_for_internal_tests({"ocr_gpu_acceleration": mode})
+            ocr._disable_gpu_acceleration()
+            assert ocr._cfg.values["ocr_gpu_acceleration"] == mode
+
+
+class TestExitOcrResetsSlowCount:
+    def test_exit_resets_pending_slow_count(self):
+        ocr = _create_ocr_for_internal_tests()
+        ocr.ocr = None
+        ocr.ocr_time = 0.0
+        ocr.ocr_count = 0
+        ocr._slow_count = 2
+        ocr.exit_ocr()
+        assert ocr._slow_count == 0
+
+
+class TestRunSlowDegradeStateMachine:
+    def _create_running_ocr(self, config_values=None):
+        from unittest.mock import MagicMock
+        from PIL import Image as PILImage
+
+        ocr = _create_ocr_for_internal_tests(config_values)
+        ocr._use_dml = True
+        ocr._dml_fallback = False
+        ocr._using_openvino = False
+        ocr._openvino_fallback = False
+        ocr._periodic_gc_interval = 0
+        ocr.ocr_time = 0.0
+        ocr.ocr_count = 0
+        ocr.img = PILImage.new("RGB", (32, 32), "white")
+
+        def make_engine():
+            engine = MagicMock()
+            engine.return_value.to_json.return_value = []
+            return engine
+
+        ocr.ocr = make_engine()
+
+        def fake_instance_ocr(force_cpu=False, force_onnx=False, **kwargs):
+            # 模拟 force_onnx 重建后的关键状态变化
+            if force_onnx:
+                ocr._use_dml = False
+                ocr.ocr = make_engine()
+        ocr.instance_ocr = MagicMock(side_effect=fake_instance_ocr)
+        return ocr
+
+    def test_consecutive_slow_calls_trigger_degrade(self):
+        ocr = self._create_running_ocr({"ocr_gpu_acceleration": "auto"})
+        ocr._slow_threshold = -1  # 任何耗时都计为一次“慢”
+        ocr._slow_consecutive = 3
+
+        degrade_calls = []
+        original_disable = OCR._disable_gpu_acceleration
+
+        def counting_disable(self_inner):
+            degrade_calls.append(1)
+            self_inner._set_mode(OCR_MODE_ONNX_CPU)
+
+        OCR._disable_gpu_acceleration = counting_disable
+        try:
+            ocr.run(ocr.img)
+            ocr.run(ocr.img)
+            assert len(degrade_calls) == 0  # 未达连续次数，不降级
+            assert ocr._slow_count == 2
+
+            ocr.run(ocr.img)
+            assert len(degrade_calls) == 1  # 第三次触发降级
+            assert ocr._cfg.values["ocr_gpu_acceleration"] == OCR_MODE_ONNX_CPU
+            assert ocr._use_dml is False  # 已切换到 ONNXRuntime(CPU)
+        finally:
+            OCR._disable_gpu_acceleration = original_disable
+
+    def test_fast_call_resets_pending_slow_count(self):
+        ocr = self._create_running_ocr()
+        ocr._slow_threshold = -1
+        ocr._slow_consecutive = 3
+
+        ocr.run(ocr.img)
+        ocr.run(ocr.img)
+        assert ocr._slow_count == 2
+
+        ocr._slow_threshold = 999999  # 恢复正常速度
+        ocr.run(ocr.img)
+        assert ocr._slow_count == 0


### PR DESCRIPTION
Fixes #1177

现象就是 issue 里说的：ocr 设了 gpu 加速，但基本每次跑都会被降回 cpu，cpu 占用反而更高。

查下来主要是 dml 第一次推理太慢（首帧要编译 shader），之前单次超过 5s 就降级；而且降级时写回的配置值是 `cpu`，在装了 OpenVINO 的环境下重启后会被重新解析成 OpenVINO——实测它的 cpu 占用比 onnxruntime(cpu) 更高，也不是用户预期的降级目标。

改动：
- `module/ocr/ocr.py`：启动时先预热一次（预热图带文字，确保 det + rec 全链路完成编译），把首帧的编译开销吃掉；改成连续 3 次超阈值才降级，偶尔卡一下不会误杀；三处 DML 降级路径统一改为 `force_onnx`，持久化值从 `cpu` 改为 `onnx_cpu`，重启后不会再被 OpenVINO 接管
- `assets/config/config.example.yaml`：新增阈值 `ocr_slow_threshold` 和次数 `ocr_slow_consecutive_threshold` 两个配置项，带范围校验（非法值回退默认），阈值设极大值可视为禁用自动降级
- `tests/test_module/test_ocr.py`：新增 10 个用例，覆盖阈值校验、降级持久化目标与连续降级状态机

预热完成的日志提到 info，默认就能看到加速有没有生效。

实测（dml，1920x1080 截图）：预热前首帧 4.56s，预热后 0.41s，稳态 0.2s 左右。
另外翻了下 release 版日志（v2026.7.26），16 天里降级了 20 次，大半在 5~6s，基本就是首帧冷启动卡到的。
