### PR TITLE
fix: 移除 requirements.txt 中无效和重复的依赖项

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,6 @@ py7zr==1.1.3
 # Desktopmagic==14.3.11; sys_platform == 'win32'
 matrix-nio==0.25.2
 python-socks[asyncio]==2.8.1
-asyncio==4.0.0
-nio==3.4.2
 pandas==3.0.3
 openpyxl==3.1.5
 selenium==4.44.0


### PR DESCRIPTION
- 移除 asyncio==4.0.0（Python 3.12+ 标准库，无需安装）
- 移除 nio==3.4.2（已废弃，与 matrix-nio==0.25.2 重复）