### PR TITLE
fix: 支持差分宇宙人才管理阶段界面

### DIFF
--- a/tasks/weekly/divergent_universe.py
+++ b/tasks/weekly/divergent_universe.py
@@ -1041,7 +1041,7 @@ class DivergentUniverse:
         检查当前界面标题，并根据不同标题执行对应的处理函数
         """
         title_crop = (96 / 1920, 63 / 1080, 142 / 1920, 34 / 1080)
-        if auto.find_element(("欢愉假面", "选择方程", "选择祝福", "选择奇物", "丢弃奇物", "愿力满盈", "选择下一站", "事件", "选择站点卡", "存档管理", "混沌药箱"), 'text', crop=title_crop, include=True):
+        if auto.find_element(("欢愉假面", "选择方程", "选择祝福", "选择奇物", "丢弃奇物", "愿力满盈", "选择下一站", "事件", "选择站点卡", "存档管理", "混沌药箱", "人才管理阶段"), 'text', crop=title_crop, include=True):
             log.info(f"检测到 “{auto.matched_text}” 界面")
             if auto.matched_text == "欢愉假面":
                 self.process_mask()
@@ -1065,6 +1065,8 @@ class DivergentUniverse:
                 self.process_save_management()
             elif auto.matched_text == "混沌药箱":
                 self.process_chaos_box()
+            elif auto.matched_text == "人才管理阶段":
+                self.process_talent_management()
             return True
         return False
 
@@ -1110,6 +1112,24 @@ class DivergentUniverse:
                 log.info("默认选择中间的面具")
                 auto.click_element(mask_positions[1], 'crop')
                 time.sleep(2)
+
+    def process_talent_management(self):
+        """
+        处理人才管理阶段界面：默认选择中间的区域卡片并确认
+        """
+        card_positions = [
+            (570 / 1920, 200 / 1080, 252 / 1920, 520 / 1080),
+            (835 / 1920, 200 / 1080, 251 / 1920, 520 / 1080),
+            (1097 / 1920, 200 / 1080, 252 / 1920, 520 / 1080),
+        ]
+        confirm_crop = (551 / 1920, 942 / 1080, 805 / 1920, 62 / 1080)
+
+        time.sleep(2)
+        log.info("默认选择中间的区域卡片")
+        auto.click_element(card_positions[1], 'crop')
+        time.sleep(1)
+        auto.click_element('确认', 'text', None, 10, crop=confirm_crop, include=True)
+        time.sleep(2)
 
     def process_equation(self):
         """


### PR DESCRIPTION
## 概述

为差分宇宙新增的 **「人才管理阶段」** 界面添加识别与自动处理逻辑。此前脚本无法识别该界面，会一直空转直至超时。

---

## 改动

- 在 `check_title()` 的标题识别列表中加入 "人才管理阶段"
- 新增 `process_talent_management()`：
  1. 默认点击中间的区域卡片
  2. 点击底部 “确认” 按钮

---

## 背景

4.5 更新后，差分宇宙在部分情况（如选取了雪鸮面具）下会进入 “人才管理阶段”，需要选择区域卡片并确认。该标题不在原有识别列表中，主循环无法分发到对应处理函数。

---

## 说明

- 选择策略为默认点击中间卡片。
- 改动已通过本地测试证实有效。