### PR TITLE
fix: 连续调试端口不可用时由系统分配端口

### DIFF
--- a/module/game/cloud.py
+++ b/module/game/cloud.py
@@ -260,14 +260,31 @@ class CloudGameController(GameControllerBase):
         return browser_path, driver_path
 
     @staticmethod
-    def _is_port_available(port: int) -> bool:
-        """检查端口是否可绑定（真实 bind 试探，TIME_WAIT 也会判不可用）"""
+    def _get_port_bind_error(port: int) -> OSError | None:
+        """检查端口是否可绑定，返回原始错误供日志诊断"""
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind(('127.0.0.1', port))
-            return True
-        except OSError:
-            return False
+            return None
+        except OSError as e:
+            return e
+
+    @classmethod
+    def _is_port_available(cls, port: int) -> bool:
+        """检查端口是否可绑定（真实 bind 试探，TIME_WAIT 也会判不可用）"""
+        return cls._get_port_bind_error(port) is None
+
+    @staticmethod
+    def _get_system_assigned_port() -> int:
+        """请求操作系统分配可用端口，避免连续端口段被整体保留"""
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(('127.0.0.1', 0))
+                return s.getsockname()[1]
+        except OSError as e:
+            error_code = getattr(e, "winerror", None) or e.errno
+            error_detail = f"错误码 {error_code}: {e}" if error_code is not None else str(e)
+            raise RuntimeError(f"系统自动分配可用端口失败（{error_detail}）") from e
 
     @staticmethod
     def _get_debug_port_from_cmdline(proc) -> int | None:
@@ -281,11 +298,17 @@ class CloudGameController(GameControllerBase):
         return None
 
     def _find_available_port(self, start_port: int, max_retry: int = 10) -> int:
-        """从 start_port 开始递增找第一个可用端口"""
-        for port in range(start_port, start_port + max_retry):
+        """优先递增查找可用端口，连续端口均不可用时由系统分配"""
+        end_port = min(start_port + max_retry, 65536)
+        for port in range(start_port, end_port):
             if self._is_port_available(port):
                 return port
-        raise RuntimeError(f"无法找到可用端口（范围: {start_port}-{start_port + max_retry - 1}）")
+        port = self._get_system_assigned_port()
+        self.log_warning(
+            f"端口范围 {start_port}-{end_port - 1} 均不可用，"
+            f"将使用系统分配的端口 {port}"
+        )
+        return port
 
     def _get_browser_arguments(self, headless) -> list[str]:
         args = [
@@ -332,9 +355,14 @@ class CloudGameController(GameControllerBase):
             configured_port = int(self.cfg.browser_debug_port)
         except (TypeError, ValueError):
             raise RuntimeError(f"browser_debug_port 配置无效: {self.cfg.browser_debug_port!r}")
+        if not 1 <= configured_port <= 65535:
+            raise RuntimeError(f"browser_debug_port 超出有效范围: {configured_port}")
         actual_port = configured_port
-        if not self._is_port_available(configured_port):
-            self.log_warning(f"端口 {configured_port} 被占用，正在查找可用端口...")
+        bind_error = self._get_port_bind_error(configured_port)
+        if bind_error is not None:
+            self.log_warning(
+                f"端口 {configured_port} 无法绑定（{bind_error}），正在查找可用端口..."
+            )
             actual_port = self._find_available_port(configured_port)
             self.log_info(f"将使用端口 {actual_port} 启动浏览器")
 

--- a/tests/test_module/test_cloud_game.py
+++ b/tests/test_module/test_cloud_game.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 from module.game.cloud import CloudGameController
 
@@ -49,3 +50,77 @@ class TestCloudGamePointerLock(unittest.TestCase):
         controller._configure_pointer_lock(headless=False)
 
         self.assertEqual(controller.driver.commands, [])
+
+
+class TestCloudGameDebugPort(unittest.TestCase):
+    def create_controller(self):
+        controller = object.__new__(CloudGameController)
+        controller.logger = FakeLogger()
+        return controller
+
+    def test_find_available_port_prefers_configured_range(self):
+        controller = self.create_controller()
+
+        with patch.object(
+            controller,
+            "_is_port_available",
+            side_effect=[False, False, True],
+        ):
+            port = controller._find_available_port(9222)
+
+        self.assertEqual(port, 9224)
+        self.assertEqual(controller.logger.warnings, [])
+
+    def test_port_bind_error_is_preserved_for_diagnostics(self):
+        bind_error = OSError(10013, "permission denied")
+        socket_context = MagicMock()
+        socket_context.__enter__.return_value.bind.side_effect = bind_error
+
+        with patch("module.game.cloud.socket.socket", return_value=socket_context):
+            result = CloudGameController._get_port_bind_error(9222)
+
+        self.assertIs(result, bind_error)
+
+    def test_find_available_port_falls_back_to_system_assigned_port(self):
+        controller = self.create_controller()
+
+        with (
+            patch.object(controller, "_is_port_available", return_value=False),
+            patch.object(controller, "_get_system_assigned_port", return_value=49152),
+        ):
+            port = controller._find_available_port(9222)
+
+        self.assertEqual(port, 49152)
+        self.assertEqual(
+            controller.logger.warnings,
+            ["端口范围 9222-9231 均不可用，将使用系统分配的端口 49152"],
+        )
+
+    def test_system_assigned_port_reports_socket_error(self):
+        socket_context = MagicMock()
+        socket_context.__enter__.return_value.bind.side_effect = OSError(
+            10013,
+            "permission denied",
+        )
+
+        with patch("module.game.cloud.socket.socket", return_value=socket_context):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"系统自动分配可用端口失败（错误码 10013:",
+            ):
+                CloudGameController._get_system_assigned_port()
+
+    def test_system_assigned_port_uses_port_zero(self):
+        socket_context = MagicMock()
+        socket_context.__enter__.return_value.getsockname.return_value = (
+            "127.0.0.1",
+            49152,
+        )
+
+        with patch("module.game.cloud.socket.socket", return_value=socket_context):
+            port = CloudGameController._get_system_assigned_port()
+
+        socket_context.__enter__.return_value.bind.assert_called_once_with(
+            ("127.0.0.1", 0)
+        )
+        self.assertEqual(port, 49152)


### PR DESCRIPTION
## 问题

PR #1144 增加了调试端口递增逻辑，但当前实现只检查配置端口开始的 10 个连续端口。Windows 的 Hyper-V、WSL、Docker 或 VPN 等组件可能动态保留连续端口段，此时所有候选端口都会绑定失败，云游戏直接报“无法找到可用端口”。

此外，现有检查会吞掉所有 OSError 并统一记录为“端口被占用”，无法区分真实占用、系统保留或权限错误。

## 修复

- 保持原有优先级：配置端口可用时行为不变。
- 继续优先递增检查原来的 10 个连续端口。
- 连续端口均不可用时，通过绑定 127.0.0.1:0 请求操作系统分配可用端口。
- 自动分配失败时保留原始 OSError 和错误码，并通过异常链返回。
- 首次配置端口绑定失败时在警告日志中输出原始系统错误。
- 校验 browser_debug_port 必须位于 1 到 65535。

## 验证

- python -m pytest tests/test_module/test_cloud_game.py -q：7 passed。
- python -m compileall：通过。
- git diff --check：通过。
- Windows 实际 socket 集成验证：占用连续 10 个端口后，成功回退到系统分配的可用端口。