### PR TITLE
fix: 补充货币战争入口交互兜底

### DIFF
--- a/assets/config/screens.json
+++ b/assets/config/screens.json
@@ -492,6 +492,9 @@
                     "auto.click_element('货币战争', 'text', None, 10, crop=(238.0 / 1920, 257.0 / 1080, 449.0 / 1920, 525.0 / 1080))",
                     "time.sleep(1)",
                     "auto.click_element('前往参与', 'text', None, 10, crop=(684.0 / 1920, 278.0 / 1080, 981.0 / 1920, 656.0 / 1080))"
+                ],
+                "actions_list_on_timeout": [
+                    "auto.press_key('f')"
                 ]
             },
             {


### PR DESCRIPTION
## 修改内容

- 为 `guide5 -> currency_wars_homepage` 增加超时操作 `auto.press_key('f')`
- 传送到货币战争桌前但仍停留在场景时，通过现有超时重检机制完成最后一次交互
- 行为与相邻的差分宇宙入口兜底保持一致

## 问题原因

「前往参与」只完成传送，部分情况下角色会停留在显示 `F 货币战争` 的交互点。原配置没有处理该交互，因此连续等待「货币战争-主界面」超时。

## 验证

- `screens.json` 可正常解析，目标 action 包含预期的 `actions_list_on_timeout`
- `python -m pytest tests/test_module/test_screen.py -q`：26 passed
- `git diff --check` 通过

Closes #1208